### PR TITLE
Added netChange event to telemetry events

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -249,7 +249,7 @@ const rollout = {
       // Only run the heuristics if user hasn't explicitly enabled/disabled DoH
       let shouldRunHeuristics = await stateManager.shouldRunHeuristics();
       if (shouldRunHeuristics) {
-        let decision = await rollout.heuristics("netChange");
+        const netChangeDecision = await rollout.heuristics("netChange");
         if (netChangeDecision === "disable_doh") {
           await stateManager.setState("disabled");
         } else {


### PR DESCRIPTION
Fixed #59 - Instead of calling the main function (which calls init), it is revised to call the netChange check. This is visible in the telemetry events log too.