### PR TITLE
Fixed #70 - Revised eslint file, added test linting, travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+    - "lts/*"
+cache: npm

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "setup-shield": "./node_modules/.bin/copyStudyUtils src/experiments",
     "ext-build": "cd src && web-ext build --overwrite-dest;",
     "lint": "eslint .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint src test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Matching the same testing structure as the [Contain Facebook](https://github.com/mozilla/contain-facebook) repo. 

@jonathanKingston I think you'll have to authorize/setup the Travis CI portion. Once this is active, we can have a code freeze on all PRs and lint the code to pass. 