### PR TITLE
Revised enable/disable logic to account for about:preferences#networking checkbox

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -59,16 +59,26 @@ const stateManager = {
     // In other words, if the user has made their own decision for DoH,
     // then we want to respect that and never run the heuristics again
 
-    if (disableHeuristics) {
+    if (disableHeuristics && curMode === 0) {
       await stateManager.rememberTRRMode();
       return false;
     } else if ( prevMode !== curMode ||  curMode === 5 ||  curMode === 3) {
       // Add logic specific if user disables DoH in about:config:
       if ( curMode === 0 ) {
+        log("manuallyDisabled");
         await stateManager.setState("manuallyDisabled");
       }
-      await stateManager.rememberDisableHeuristics();
-      await stateManager.rememberTRRMode();
+      if ( curMode === 3 || curMode === 2  ) {
+        // Turn DoH Back On, Reset Failsafe Check
+        await stateManager.setState("enabled");
+        await rollout.setSetting("doh-rollout.disable-heuristics", false);
+      } else {
+        // Disable DoH
+        await stateManager.setState("disabled");
+        await stateManager.rememberTRRMode();
+        await stateManager.rememberDisableHeuristics();
+      }
+
       return false;
     }
     return true;

--- a/src/background.js
+++ b/src/background.js
@@ -76,7 +76,7 @@ const stateManager = {
         await stateManager.rememberDisableHeuristics();
       } else {
         // Check if trr.mode is not in default value.
-        await rollout.prefHasUserValueCheck();
+        await rollout.trrModePrefHasUserValueCheck();
       }
       return false;
     }
@@ -173,9 +173,9 @@ const rollout = {
     await browser.storage.local.set({[name]: value});
   },
 
-  async prefHasUserValueCheck() {
-    log("prefHasUserValueCheck");
-    // This confirms if a user has modified DoH outside of the addon
+  async trrModePrefHasUserValueCheck() {
+    log("trrModePrefHasUserValueCheck");
+    // This confirms if a user has modified DoH (via the TRR_MODE_PREF) outside of the addon
     // This runs only on the FIRST time that add-on is enabled, and if the stored pref
     // mismatches the current pref (Meaning something outside of the add-on has changed it
     if (
@@ -195,7 +195,7 @@ const rollout = {
     if (!doneFirstRun) {
       log("first run!");
       this.setSetting("doneFirstRun", true);
-      await this.prefHasUserValueCheck();
+      await this.trrModePrefHasUserValueCheck();
 
     } else {
       log("not first run!");

--- a/src/background.js
+++ b/src/background.js
@@ -43,10 +43,18 @@ const stateManager = {
   },
 
   async shouldRunHeuristics() {
+    // Check if heursitics has been disabled from rememberDisableHeuristics()
+    let disableHeuristics = await rollout.getSetting("doh-rollout.disable-heuristics", false);
+    if (disableHeuristics) {
+      // Do not modify DoH for this user.
+      log("disableHeuristics has been enabled.");
+      return false;
+    }
+
     let prevMode = await rollout.getSetting("doh-rollout.previous.trr.mode", 0);
     let curMode = await browser.experiments.preferences.getUserPref(
       TRR_MODE_PREF, 0);
-    let disableHeuristics = await rollout.getSetting("doh-rollout.disable-heuristics", false);
+
     log("Comparing previous trr mode to current mode:",
       prevMode, curMode);
 
@@ -59,29 +67,22 @@ const stateManager = {
     // In other words, if the user has made their own decision for DoH,
     // then we want to respect that and never run the heuristics again
 
-    if (disableHeuristics && curMode === 0) {
-      await stateManager.rememberTRRMode();
-      return false;
-    } else if ( prevMode !== curMode ||  curMode === 5 ||  curMode === 3) {
-      // Add logic specific if user disables DoH in about:config:
-      if ( curMode === 0 ) {
-        log("manuallyDisabled");
-        await stateManager.setState("manuallyDisabled");
-      }
-      if ( curMode === 3 || curMode === 2  ) {
-        // Turn DoH Back On, Reset Failsafe Check
-        await stateManager.setState("enabled");
-        await rollout.setSetting("doh-rollout.disable-heuristics", false);
-      } else {
-        // Disable DoH
-        await stateManager.setState("disabled");
-        await stateManager.rememberTRRMode();
-        await stateManager.rememberDisableHeuristics();
-      }
+    // On Mismatch - run never run again (make init check a function)
 
+    if (prevMode !== curMode) {
+      log("Mismatched, curMode: ", curMode);
+      if (curMode === 0) {
+        // If user has manually set trr.mode to 0, and it was previously something else.
+        await stateManager.rememberDisableHeuristics();
+      } else {
+        // Check if trr.mode is not in default value.
+        await rollout.prefHasUserValueCheck();
+      }
       return false;
     }
+
     return true;
+
   },
 
   async shouldShowDoorhanger() {
@@ -117,6 +118,7 @@ const rollout = {
     await stateManager.setState("UIDisabled");
     await stateManager.rememberDoorhangerDecision("UIDisabled");
     await stateManager.rememberDoorhangerPingSent();
+    await stateManager.rememberDisableHeuristics();
   },
 
   async netChangeListener(reason) {
@@ -171,12 +173,30 @@ const rollout = {
     await browser.storage.local.set({[name]: value});
   },
 
+  async prefHasUserValueCheck() {
+    log("prefHasUserValueCheck");
+    // This confirms if a user has modified DoH outside of the addon
+    // This runs only on the FIRST time that add-on is enabled, and if the stored pref
+    // mismatches the current pref (Meaning something outside of the add-on has changed it
+    if (
+      await browser.experiments.preferences.prefHasUserValue(
+        TRR_MODE_PREF)
+    ) {
+      // TODO: Add telemtery ping for user who already has pref on DoH
+      await stateManager.rememberDisableHeuristics();
+      return;
+    }
+  },
+
   async init() {
     log("calling init");
     let doneFirstRun = await this.getSetting("doneFirstRun");
+
     if (!doneFirstRun) {
       log("first run!");
       this.setSetting("doneFirstRun", true);
+      await this.prefHasUserValueCheck();
+
     } else {
       log("not first run!");
     }

--- a/src/experiments/doorhanger/api.js
+++ b/src/experiments/doorhanger/api.js
@@ -54,18 +54,8 @@ class DoorhangerEventEmitter extends EventEmitter {
       },
     ];
 
-    let doorhangerEvents = event => {
-      // If additional event listening is needed, recommend switching
-      // to a switch case statement.
-      if (event !== "dismissed") {
-        return;
-      }
-      // On notification removal (switch away from active tab, close tab), enable DoH preference 
-      self.emit("doorhanger-accept", tabId);
-      recentWindow.PopupNotifications.remove(notification);
-    };
-
     let learnMoreURL = Services.urlFormatter.formatURL("https://support.mozilla.org/%LOCALE%/kb/firefox-dns-over-https");
+
     const options = {
       hideClose: true,
       persistWhileVisible: true,
@@ -78,7 +68,20 @@ class DoorhangerEventEmitter extends EventEmitter {
       eventCallback: doorhangerEvents,
       removeOnDismissal: false,
     };
+
     let notification = recentWindow.PopupNotifications.show(browser, "doh-first-time", text, null, primaryAction, secondaryActions, options);
+
+    let doorhangerEvents = event => {
+      // If additional event listening is needed, recommend switching
+      // to a switch case statement.
+      if (event !== "dismissed") {
+        return;
+      }
+      // On notification removal (switch away from active tab, close tab), enable DoH preference
+      self.emit("doorhanger-accept", tabId);
+      recentWindow.PopupNotifications.remove(notification);
+    };
+
   }
 }
 

--- a/src/experiments/doorhanger/api.js
+++ b/src/experiments/doorhanger/api.js
@@ -54,8 +54,21 @@ class DoorhangerEventEmitter extends EventEmitter {
       },
     ];
 
+    let notification;
+
     let learnMoreURL = Services.urlFormatter.formatURL("https://support.mozilla.org/%LOCALE%/kb/firefox-dns-over-https");
 
+    let doorhangerEvents = event => {
+      // If additional event listening is needed, recommend switching
+      // to a switch case statement.
+      if (event !== "dismissed") {
+        return;
+      }
+      // On notification removal (switch away from active tab, close tab), enable DoH preference
+      self.emit("doorhanger-accept", tabId);
+      recentWindow.PopupNotifications.remove(notification);
+    };
+    
     const options = {
       hideClose: true,
       persistWhileVisible: true,
@@ -69,19 +82,9 @@ class DoorhangerEventEmitter extends EventEmitter {
       removeOnDismissal: false,
     };
 
-    let notification = recentWindow.PopupNotifications.show(browser, "doh-first-time", text, null, primaryAction, secondaryActions, options);
 
-    let doorhangerEvents = event => {
-      // If additional event listening is needed, recommend switching
-      // to a switch case statement.
-      if (event !== "dismissed") {
-        return;
-      }
-      // On notification removal (switch away from active tab, close tab), enable DoH preference
-      self.emit("doorhanger-accept", tabId);
-      recentWindow.PopupNotifications.remove(notification);
-    };
 
+    notification = recentWindow.PopupNotifications.show(browser, "doh-first-time", text, null, primaryAction, secondaryActions, options);
   }
 }
 

--- a/src/experiments/doorhanger/api.js
+++ b/src/experiments/doorhanger/api.js
@@ -57,11 +57,12 @@ class DoorhangerEventEmitter extends EventEmitter {
     let doorhangerEvents = event => {
       // If additional event listening is needed, recommend switching
       // to a switch case statement.
-      if (event !== "removed") {
+      if (event !== "dismissed") {
         return;
       }
       // On notification removal (switch away from active tab, close tab), enable DoH preference 
       self.emit("doorhanger-accept", tabId);
+      recentWindow.PopupNotifications.remove(notification);
     };
 
     let learnMoreURL = Services.urlFormatter.formatURL("https://support.mozilla.org/%LOCALE%/kb/firefox-dns-over-https");
@@ -75,9 +76,9 @@ class DoorhangerEventEmitter extends EventEmitter {
       learnMoreURL,
       escAction: "buttoncommand",
       eventCallback: doorhangerEvents,
-      removeOnDismissal: true,
+      removeOnDismissal: false,
     };
-    recentWindow.PopupNotifications.show(browser, "doh-first-time", text, null, primaryAction, secondaryActions, options);
+    let notification = recentWindow.PopupNotifications.show(browser, "doh-first-time", text, null, primaryAction, secondaryActions, options);
   }
 }
 

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -51,6 +51,9 @@ ExtensionPreferencesManager.addSetting("dohRollout.state", {
 });
 
 const prefManager = {
+  prefHasUserValue(name) {
+    return Services.prefs.prefHasUserValue(name);
+  },
   getUserPref(name, value) {
     if (!Services.prefs.prefHasUserValue(name)) {
       return value;
@@ -78,6 +81,10 @@ var preferences = class preferences extends ExtensionAPI {
         preferences: {
           async getUserPref(name, value) {
             return prefManager.getUserPref(name, value);
+          },
+
+          async prefHasUserValue(name) {
+            return prefManager.prefHasUserValue(name);
           },
 
           onPrefChanged: new EventManager({

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -32,10 +32,8 @@ ExtensionPreferencesManager.addSetting("dohRollout.state", {
     case "uninstalled":
       break;
     case "disabled":
-      prefs[TRR_MODE_PREF] = 0;
       break;
     case "manuallyDisabled":
-      prefs[TRR_MODE_PREF] = 0;
       break;
     case "UIOk":
     case "UITimeout":

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -35,6 +35,8 @@ ExtensionPreferencesManager.addSetting("dohRollout.state", {
       prefs[TRR_MODE_PREF] = 0;
       break;
     case "manuallyDisabled":
+      prefs[TRR_MODE_PREF] = 0;
+      break;
     case "UIOk":
     case "UITimeout":
     case "enabled":

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -95,7 +95,19 @@
             "name": "value"
           }
         ],
-        "async": true 
+        "async": true
+      },
+      {
+        "name": "prefHasUserValue",
+        "type": "function",
+        "description": "Check if the user has set a value of a preference",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "name"
+          }
+        ],
+        "async": true
       }
     ],
     "properties": {


### PR DESCRIPTION
## Testing Steps

### Method A: Enable to Disable

1. Add `doh-rollout.enabled` boolean pref, set to `true`
1. On doorhanger notification, select **enable** protections 
1. Go to [about:preferences#general](about:preferences#general) and click "Settings" button in Network Settings section. 
1. Uncheck "Enable DNS over HTTPS" 
1. Go back to [about:debugging](about:debugging#/runtime/this-firefox) and click "Reload" on the add-on. 
1. DoH should be disabled. Confirm by checking about:telemtery or that the `network.trr.mode` pref to confirm it is set to `0`.

### Method B: Disable to Enable

1. Add `doh-rollout.enabled` boolean pref, set to `true`
1. On doorhanger notification, select **disable** protections 
1. Confirm by that the `network.trr.mode` pref to confirm it is set to `5`.
1. Go to [about:preferences#general](about:preferences#general) and click "Settings" button in Network Settings section. 
1. Check "Enable DNS over HTTPS" 
1. Go back to [about:debugging](about:debugging#/runtime/this-firefox) and click "Reload" on the add-on. 
1. DoH should be enabled now. **However, the add-on has no visibility on this, as its been set to a custom setting by the user.**   ~Confirm by checking about:telemtery or that the `network.trr.mode` pref to confirm it is set to `2`.~ 