### PR TITLE
Fixed #88 - Refactored sleep function in onConnectionChanged event

### DIFF
--- a/src/experiments/netChange/api.js
+++ b/src/experiments/netChange/api.js
@@ -19,6 +19,7 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+let last_event = Date.now();
 
 var netChange = class netChange extends ExtensionAPI { 
   getAPI(context) {
@@ -30,20 +31,21 @@ var netChange = class netChange extends ExtensionAPI {
             name: "netChange.onConnectionChanged",
             register: fire => {
               let observer = async (subject, topic, data) => {
+                // if we get "up" event we should fire an event.
+                if (data === "up") {
+                  last_event = Date.now();
+                  fire.async(data);
+                }
+
                 if (data === "changed") {
-                  // The "changed" event sometimes fires when the connection 
-                  // isn't quite up yet. We should wait before running the 
-                  // heuristics to ensure the network is up.
-                  await sleep(5000);
-  
-                  // After sleeping, check the connection again
-                  if (gNetworkLinkService.linkStatusKnown &&
-                      gNetworkLinkService.isLinkUp &&
-                      data === "changed") {
+                  // We will coalesce event that are less than 5s apart.
+                  if ( Date.now() - last_event > 5000 &&  gNetworkLinkService.linkStatusKnown && gNetworkLinkService.isLinkUp) {
+                    last_event = Date.now();
                     fire.async(data);
                   }
                 }
               };
+
               Services.obs.addObserver(observer, "network:link-status-changed");
               return () => {
                 Services.obs.removeObserver(observer, "network:link-status-changed");


### PR DESCRIPTION
This change will only check for "up" after a  "changed" event once each 5 seconds while reconnecting to networks. 