### PR TITLE
Fixed #100 - Revised timeout to 30s from 5s

### DIFF
--- a/src/experiments/netChange/api.js
+++ b/src/experiments/netChange/api.js
@@ -39,7 +39,7 @@ var netChange = class netChange extends ExtensionAPI {
 
                 if (data === "changed") {
                   // We will coalesce event that are less than 5s apart.
-                  if ( Date.now() - last_event > 5000 &&  gNetworkLinkService.linkStatusKnown && gNetworkLinkService.isLinkUp) {
+                  if ( Date.now() - last_event > 30000 &&  gNetworkLinkService.linkStatusKnown && gNetworkLinkService.isLinkUp) {
                     last_event = Date.now();
                     fire.async(data);
                   }

--- a/src/experiments/netChange/api.js
+++ b/src/experiments/netChange/api.js
@@ -38,7 +38,7 @@ var netChange = class netChange extends ExtensionAPI {
                 }
 
                 if (data === "changed") {
-                  // We will coalesce event that are less than 5s apart.
+                  // We will coalesce event that are less than 30s apart.
                   if ( Date.now() - last_event > 30000 &&  gNetworkLinkService.linkStatusKnown && gNetworkLinkService.isLinkUp) {
                     last_event = Date.now();
                     fire.async(data);


### PR DESCRIPTION
This reduce bogus telemetry calls on the "changed" event while listening to all netChange events. 