### PR TITLE
Removed UITimeout event and logic

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -88,15 +88,6 @@ const stateManager = {
   async shouldShowDoorhanger() {
     let doorhangerShown = await rollout.getSetting("doh-rollout.doorhanger-shown", false);
     let doorhangerPingSent = await rollout.getSetting("doh-rollout.doorhanger-ping-sent", false);
-
-    // If we've shown the doorhanger but haven't sent the ping,
-    // we assume that the doorhanger timed out
-    if (doorhangerShown && !(doorhangerPingSent)) {
-      await stateManager.setState("UITimeout");
-      await stateManager.rememberDoorhangerDecision("UITimeout");
-      await stateManager.rememberDoorhangerPingSent();
-    }
-
     log("Should show doorhanger:", !doorhangerShown);
     return !doorhangerShown;
   }

--- a/src/experiments/heuristics/api.js
+++ b/src/experiments/heuristics/api.js
@@ -25,7 +25,7 @@ const TELEMETRY_EVENTS = {
   "state": {
     methods: ["state"],
     objects: ["loaded", "enabled", "disabled", "manuallyDisabled", "uninstalled",
-      "UIOk", "UIDisabled", "UITimeout"],
+      "UIOk", "UIDisabled"],
     extra_keys: [],
     record_on_release: true,
   }

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -36,7 +36,6 @@ ExtensionPreferencesManager.addSetting("dohRollout.state", {
     case "manuallyDisabled":
       break;
     case "UIOk":
-    case "UITimeout":
     case "enabled":
       prefs[TRR_MODE_PREF] = 2;
       break;


### PR DESCRIPTION
Fixes #115 

As we have no Timeout function attached to the notification UI, this has been removed. 

To trigger this event (before this PR), do the following: 
- Run `web-ext`, add `doh-rollout.enabled` pref set to `true`
- Close tab (Most likely `about:config`) with popup notification  (without clicking enable/disable)
  - _Note - This enables DoH but does not send any specific state event_
- Go to `about:debugging` and reload plugin
- Go to `about:telemetry` and observe events 