### PR TITLE
Fixed #114 - Revised doorhanger events

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -23,6 +23,8 @@ const stateManager = {
   },
 
   async rememberDoorhangerShown() {
+    // This will be shown on startup and netChange events until a user clicks
+    // to confirm/disable DoH or presses the esc key (confirming)
     log("Remembering that doorhanger has been shown");
     await rollout.setSetting("doh-rollout.doorhanger-shown", true);
   },
@@ -90,7 +92,32 @@ const stateManager = {
     let doorhangerPingSent = await rollout.getSetting("doh-rollout.doorhanger-ping-sent", false);
     log("Should show doorhanger:", !doorhangerShown);
     return !doorhangerShown;
+  },
+
+  async showDoorHangerAndEnableDoH() {
+    browser.experiments.doorhanger.onDoorhangerAccept.addListener(
+      rollout.doorhangerAcceptListener
+    );
+    browser.experiments.doorhanger.onDoorhangerDecline.addListener(
+      rollout.doorhangerDeclineListener
+    );
+    await browser.experiments.doorhanger.show({
+      name: browser.i18n.getMessage("doorhangerName"),
+      text: "<> " + browser.i18n.getMessage("doorhangerBody"),
+      okLabel: browser.i18n.getMessage("doorhangerButtonOk"),
+      okAccessKey: browser.i18n.getMessage("doorhangerButtonOkAccessKey"),
+      cancelLabel: browser.i18n.getMessage("doorhangerButtonCancel"),
+      cancelAccessKey: browser.i18n.getMessage("doorhangerButtonCancelAccessKey"),
+    });
+
+    // Be default, enable DoH when showing the doorhanger,
+    // if heuristics returned no reason to not run.
+    await stateManager.setState("enabled");
+    return;
   }
+
+
+
 };
 
 
@@ -102,6 +129,7 @@ const rollout = {
     await stateManager.setState("UIOk");
     await stateManager.rememberDoorhangerDecision("UIOk");
     await stateManager.rememberDoorhangerPingSent();
+    await stateManager.rememberDoorhangerShown();
   },
 
   async doorhangerDeclineListener(tabId) {
@@ -110,6 +138,7 @@ const rollout = {
     await stateManager.rememberDoorhangerDecision("UIDisabled");
     await stateManager.rememberDoorhangerPingSent();
     await stateManager.rememberDisableHeuristics();
+    await stateManager.rememberDoorhangerShown();
   },
 
   async netChangeListener(reason) {
@@ -206,10 +235,14 @@ const rollout = {
       log("onConnectionChanged");
       // Only run the heuristics if user hasn't explicitly enabled/disabled DoH
       let shouldRunHeuristics = await stateManager.shouldRunHeuristics();
+      let shouldShowDoorhanger = await stateManager.shouldShowDoorhanger();
+
       if (shouldRunHeuristics) {
         const netChangeDecision = await rollout.heuristics("netChange");
         if (netChangeDecision === "disable_doh") {
           await stateManager.setState("disabled");
+        } else if (shouldShowDoorhanger) {
+          await stateManager.showDoorHangerAndEnableDoH();
         } else {
           await stateManager.setState("enabled");
         }
@@ -251,28 +284,14 @@ const rollout = {
     // If the heuristics say to enable DoH, determine if the doorhanger
     // should be shown
     } else if (shouldShowDoorhanger) {
-      browser.experiments.doorhanger.onDoorhangerAccept.addListener(
-        rollout.doorhangerAcceptListener
-      );
-      browser.experiments.doorhanger.onDoorhangerDecline.addListener(
-        rollout.doorhangerDeclineListener
-      );
-      await browser.experiments.doorhanger.show({
-        name: browser.i18n.getMessage("doorhangerName"),
-        text: "<> " + browser.i18n.getMessage("doorhangerBody"),
-        okLabel: browser.i18n.getMessage("doorhangerButtonOk"),
-        okAccessKey: browser.i18n.getMessage("doorhangerButtonOkAccessKey"),
-        cancelLabel: browser.i18n.getMessage("doorhangerButtonCancel"),
-        cancelAccessKey: browser.i18n.getMessage("doorhangerButtonCancelAccessKey"),
-      });
-
-      await stateManager.rememberDoorhangerShown();
-
-    // If the doorhanger doesn't need to be shown and the heuristics
-    // say to enable DoH, enable it
+      await stateManager.showDoorHangerAndEnableDoH();
     } else {
+      // Doorhanger has been shown before and did not opt-out
       await stateManager.setState("enabled");
     }
+
+
+
   },
 };
 

--- a/src/experiments/doorhanger/api.js
+++ b/src/experiments/doorhanger/api.js
@@ -58,17 +58,6 @@ class DoorhangerEventEmitter extends EventEmitter {
 
     let learnMoreURL = Services.urlFormatter.formatURL("https://support.mozilla.org/%LOCALE%/kb/firefox-dns-over-https");
 
-    let doorhangerEvents = event => {
-      // If additional event listening is needed, recommend switching
-      // to a switch case statement.
-      if (event !== "dismissed") {
-        return;
-      }
-      // On notification removal (switch away from active tab, close tab), enable DoH preference
-      self.emit("doorhanger-accept", tabId);
-      recentWindow.PopupNotifications.remove(notification);
-    };
-    
     const options = {
       hideClose: true,
       persistWhileVisible: true,
@@ -78,7 +67,6 @@ class DoorhangerEventEmitter extends EventEmitter {
       popupIconURL: "chrome://browser/skin/connection-secure.svg",
       learnMoreURL,
       escAction: "buttoncommand",
-      eventCallback: doorhangerEvents,
       removeOnDismissal: false,
     };
 


### PR DESCRIPTION
This PR overhauls the doorhanger interactions.

Note: **If the doorhanger has been shown, DoH has been enabled.** Events mentioned further are specific to the doorhanger logic, not enabling/disabling DoH. 

**Expected results:**
- On both startup and netchange events the doorhanger will show if: 
  - Heuristics determine DoH can be enabled (which has its own checks) 
  - User has not interacted with the doorhanger (Clicked "OK, Got It", "Disable Protection" or clicked the ESC key) yet

Once the user has opted in or out, the door hanger will not be shown again. 

**Edge cases:**
- If the user closes the tab with the doorhanger shown or quits the browser entirely, no event occurs. The doorhanger will not be shown again until the next startup or netchange event, and the notification will display on whichever tab is active. 
- Switching to a new tab away from the active notification will not trigger any events or dismiss the notification 
- Clicking learn more link will not trigger any events or dismiss the notification 