### PR TITLE
Remove unused shield-study-addon-utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/src/web-ext-artifacts
 *.swp
 /node_modules
-/src/lib
 /dist

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {
-		"build": "mkdir src/lib/; npm run ext-build && npm run setup-shield",
-		"setup-shield": "./node_modules/.bin/copyStudyUtils src/experiments",
-		"ext-build": "cd src && web-ext build --overwrite-dest;",
+		"build": "web-ext build --overwrite-dest --source-dir src",
 		"lint": "eslint .",
 		"test": "eslint src test"
 	},
@@ -26,7 +24,6 @@
 	},
 	"homepage": "https://github.com/mozilla/doh-rollout#readme",
 	"dependencies": {
-		"shield-studies-addon-utils": "^5.2.1",
 		"web-ext": "^3.1.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This library is commonly used in Shield studies. This add-on is not a
Shield study (since it is intended to be released via Balrog) and does
not use the study utils for anything.

Removing this library reduces the size of the built XPI by over 80%, and
decreases the time it takes to build the add-on.