### PR TITLE
Fixed #94 - Revised startup checks to look for enterprise policies, and set them accordingly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/src/web-ext-artifacts
 *.swp
 /node_modules
-/src/lib
 /dist

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,6 +12,7 @@ The event extras include:
 * `google`: whether the resolver configured by the OS uses [forced SafeSearch]
 * `youtube`: whether the resolver configured by the OS resolves YouTube to restricted YouTube
 * `canary`: whether the resolver configured by the OS uses the [application DNS canary] to request that application DNS (like DoH) is disabled
+* `zscalerCanary`: whether the Zscaler's Shift service is being used on the network
 * `modifiedRoots`: whether the `security.enterprise_roots.enabled` pref is true
 * `browserParent`: whether Firefox parental controls are enabled
 * `thirdPartyRoots`: if third-party roots are included in the Firefox trust store

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -16,7 +16,7 @@ The event extras include:
 * `modifiedRoots`: whether the `security.enterprise_roots.enabled` pref is true
 * `browserParent`: whether Firefox parental controls are enabled
 * `thirdPartyRoots`: if third-party roots are included in the Firefox trust store
-* `policy`: if Firefox enterprise policies are active and DoH is not explicitly allowed
+* `policy`: if Firefox enterprise policies are active and DoH is disabled
 * `evaluateReason`: why heuristics were evaluated
 
 # State events

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,6 +6,14 @@ All events are sent with category `doh`.
 
 Evaluate events are sent on startup and network change, with method "evaluate" and object "heuristics".
 
+The event value can be the following:
+- `enable_doh`: Safe to enable DoH
+- `disable_doh`: DoH should not be enabled based on heuristics
+- Other:
+  - `prefHasUserValue`: User already have a value for `network.trr.mode`, so the add-on will not modify DoH settings. 
+  - `doorhangerDecline`: User clicked no on the doorhanger, opting out of the study.
+  - `userModified`: The user manually updated the `network.trr.mode`, so the study has been disabled.
+
 The event value is either `enable_doh` or `disable_doh`, reflecting the result of the evaluation.
 
 The event extras include:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "0.0.9-rc1",
+	"version": "0.0.10",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {
-		"build": "mkdir src/lib/; npm run ext-build && npm run setup-shield",
-		"setup-shield": "./node_modules/.bin/copyStudyUtils src/experiments",
-		"ext-build": "cd src && web-ext build --overwrite-dest;",
+		"build": "web-ext build --overwrite-dest --source-dir src",
 		"lint": "eslint .",
 		"test": "eslint src test"
 	},
@@ -26,7 +24,6 @@
 	},
 	"homepage": "https://github.com/mozilla/doh-rollout#readme",
 	"dependencies": {
-		"shield-studies-addon-utils": "^5.2.1",
 		"web-ext": "^3.1.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "0.0.9",
+	"version": "0.0.9-rc1",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -74,7 +74,7 @@ const stateManager = {
 
     if (prevMode !== curMode) {
       log("Mismatched, curMode: ", curMode);
-      if (curMode === 0) {
+      if (curMode === 0 || curMode === 5) {
         // If user has manually set trr.mode to 0, and it was previously something else.
         await stateManager.rememberDisableHeuristics();
       } else {
@@ -225,6 +225,8 @@ const rollout = {
     // Reset skipHeuristicsCheck
     this.setSetting("skipHeuristicsCheck", false);
 
+    // TODO: Flip Policy Check and User Pref Check + Update Notes
+
     // This confirms if a user has modified DoH (via the TRR_MODE_PREF) outside of the addon
     // This runs only on the FIRST time that add-on is enabled, and if the stored pref
     // mismatches the current pref (Meaning something outside of the add-on has changed it
@@ -232,7 +234,7 @@ const rollout = {
       await browser.experiments.preferences.prefHasUserValue(
         TRR_MODE_PREF)
     ) {
-      // TODO: Add telemtery ping for user who already has pref on DoH
+      // TODO: Add telemtery ping for user who already has pref on DoH!
       await stateManager.rememberDisableHeuristics();
       return;
     }

--- a/src/experiments/heuristics/api.js
+++ b/src/experiments/heuristics/api.js
@@ -19,7 +19,7 @@ const TELEMETRY_EVENTS = {
   "evaluate": {
     methods: [ "evaluate" ],
     objects: [ "heuristics" ],
-    extra_keys: ["google", "youtube", "canary", "modifiedRoots", "browserParent", "thirdPartyRoots", "policy", "evaluateReason"],
+    extra_keys: ["google", "youtube", "zscalerCanary", "canary", "modifiedRoots", "browserParent", "thirdPartyRoots", "policy", "evaluateReason"],
     record_on_release: true,
   },
   "state": {

--- a/src/experiments/heuristics/api.js
+++ b/src/experiments/heuristics/api.js
@@ -65,8 +65,8 @@ const heuristicsManager = {
       }
     }
 
-    // Enable DoH by default
-    return "enable_doh";
+    // Default return, meaning no policy rekated to DNSOverHTTPS
+    return "no_policy_set";
   },
 
   async checkParentalControls() {

--- a/src/experiments/heuristics/schema.json
+++ b/src/experiments/heuristics/schema.json
@@ -32,6 +32,10 @@
                 "description": "Indicates whether YouTube safe-search is enabled",
                 "type": "string"
               },
+              "zscalerCanary": {
+                "description": "Indicates whether Zscaler's Shift is enabled",
+                "type": "string"
+              },
               "canary": {
                 "description": "Indicates whether global canary domain was filtered",
                 "type": "string"

--- a/src/heuristics.js
+++ b/src/heuristics.js
@@ -90,6 +90,22 @@ async function safeSearch() {
   return safeSearchChecks;
 }
 
+
+async function zscalerCanary() {
+  const ZSCALER_CANARY = "www.justmalicious.com";
+  let {addresses, _} = await dnsLookup(ZSCALER_CANARY);
+  for (let j = 0; j < addresses.length; j++) {
+    let answer = addresses[j];
+    if (answer == "52.10.123.63" || answer == "52.41.181.205") {
+      // if www.justmalicious.com resolves to either one of the two IPs above,
+      // Zscaler Shift service is in use, don't enable DoH
+      return "disable_doh";
+    }
+  }
+  return "enable_doh"
+}
+
+
 // TODO: Confirm the expected behavior when filtering is on
 async function globalCanary() {
   let {addresses, err} = await dnsLookup(GLOBAL_CANARY);
@@ -115,6 +131,7 @@ async function modifiedRoots() {
 
 async function runHeuristics() {
   let safeSearchChecks = await safeSearch();
+  let zscalerCheck = await zscalerCanary();
   let canaryCheck = await globalCanary();
   let modifiedRootsCheck = await modifiedRoots();
 
@@ -126,6 +143,7 @@ async function runHeuristics() {
   // Return result of each heuristic
   let heuristics = {"google": safeSearchChecks.google,
     "youtube": safeSearchChecks.youtube,
+    "zscalerCanary": zscalerCheck,
     "canary": canaryCheck,
     "modifiedRoots": modifiedRootsCheck,
     "browserParent": browserParentCheck,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "0.0.9-rc1",
+  "version": "0.0.10",
 
   "hidden": true,
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "0.0.9",
+  "version": "0.0.9-rc1",
 
   "hidden": true,
 


### PR DESCRIPTION
Note: No conflicts!  ~This will conflict with the other open PR #119~ 

**Telemetry Updates:**
This commit overhauls how policy checks are sent, including revising the telemetry events slightly. Rather than just on `startup` and `netChange`, it now includes the following:
- `first_run`: Runs the very first time on startup in cases when an enterprise policy is set. This doesn't run if an enterprise policy is not detected _(Normal `startup` event runs instead)_. 
- `shouldRunHeuristics_mismatch`: This runs when during any normal heuristics check, and detects that following conditions: user has not opted out, the cached version of TRR.mode has changed from what the current mode is and DoH is not disabled. 

Additionally, the huestiric results checks across the various areas and returns either a "disable_doh" or "enable_doh". To remove false positives, the `checkEnterprisePolicies` [function](https://github.com/mozilla/doh-rollout/blob/94-enterprise-policy/src/experiments/heuristics/api.js#L68-L69) also returns `no_policy_set`. As this isn't an explicit reason to disable DoH, it doesn't change functionality outside of the new logic to check Policies first. 

**Expected Results:**
- If a user has a value set for `network.trr.mode`, and an enterprise policy set, the policy is respected above all else. 
- If a policy is detected, a specific telemetry event is fired, in addition to enabling/disabling DoH. 