### PR TITLE
Fixed #72 - Revised netChange event fire to only fire when applicable. 

### DIFF
--- a/src/experiments/netChange/api.js
+++ b/src/experiments/netChange/api.js
@@ -31,17 +31,18 @@ var netChange = class netChange extends ExtensionAPI {
             name: "netChange.onConnectionChanged",
             register: fire => {
               let observer = async (subject, topic, data) => {
-                if (netChangeWaiting == false) {
-                  if (data === "changed" || data === "up") {
-                    netChangeWaiting = true;
-                    await sleep(5000);
-
-                    if (gNetworkLinkService.linkStatusKnown &&
-                       gNetworkLinkService.isLinkUp) {
-                      fire.async(data);
-                    }
-                    netChangeWaiting = false;
+                if (netChangeWaiting) {
+                  return;
+                }
+                if (data === "changed" || data === "up") {
+                  // Trigger the netChangeWaiting switch, initiating 5sec timeout 
+                  netChangeWaiting = true;
+                  await sleep(5000);
+                  if (gNetworkLinkService.linkStatusKnown && gNetworkLinkService.isLinkUp) {
+                    fire.async(data);
                   }
+                  // Reset the netChangeWaiting switch
+                  netChangeWaiting = false;
                 }
               };
 


### PR DESCRIPTION

Now it only fires netChange events when both linkStatusKnown and isLinkUp are true. I also reverted sleep timeout to 5s, as this works properly now, and won't fire the telemetry event without proper logic. 