### PR TITLE
Fixed 94 - Removed logic to only check for policies/userPref on first run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -241,6 +241,9 @@ const rollout = {
     if (policyEnableDoH === "enable_doh" || policyEnableDoH === "disable_doh") {
       // Don't check for prefHasUserValue if policy is set to disable DoH
       this.setSetting("skipHeuristicsCheck", true);
+    } else {
+      // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
+      this.setSetting("skipHeuristicsCheck", false);
     }
     return;
   },

--- a/src/background.js
+++ b/src/background.js
@@ -228,12 +228,10 @@ const rollout = {
     switch (policyEnableDoH) {
     case "enable_doh":
       log("Policy requires DoH enabled.");
-      await stateManager.setState("enabled");
       browser.experiments.heuristics.sendHeuristicsPing(policyEnableDoH, results);
       break;
     case "disable_doh":
       log("Policy requires DoH to be disabled.");
-      await stateManager.setState("disabled");
       browser.experiments.heuristics.sendHeuristicsPing(policyEnableDoH, results);
       break;
     case "no_policy_set":
@@ -243,6 +241,9 @@ const rollout = {
     if (policyEnableDoH === "enable_doh" || policyEnableDoH === "disable_doh") {
       // Don't check for prefHasUserValue if policy is set to disable DoH
       this.setSetting("skipHeuristicsCheck", true);
+    } else {
+      // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
+      this.setSetting("skipHeuristicsCheck", false);
     }
     return;
   },
@@ -260,6 +261,7 @@ const rollout = {
       await this.trrModePrefHasUserValueAndEnterprisePolicyCheck("first_run");
     } else {
       log("not first run!");
+      await this.trrModePrefHasUserValueAndEnterprisePolicyCheck("startup");
     }
 
     // Only run the heuristics if user hasn't explicitly enabled/disabled DoH

--- a/src/background.js
+++ b/src/background.js
@@ -230,6 +230,11 @@ const rollout = {
       log("Policy requires DoH enabled.");
       browser.experiments.heuristics.sendHeuristicsPing(policyEnableDoH, results);
       break;
+    case "policy_without_doh":
+      log("Policy does not mention DoH.");
+      await stateManager.setState("disabled");
+      browser.experiments.heuristics.sendHeuristicsPing(policyEnableDoH, results);
+      break;
     case "disable_doh":
       log("Policy requires DoH to be disabled.");
       browser.experiments.heuristics.sendHeuristicsPing(policyEnableDoH, results);
@@ -238,12 +243,12 @@ const rollout = {
     }
 
     // Determine to skip additional heuristics (by presence of an enterprise policy)
-    if (policyEnableDoH === "enable_doh" || policyEnableDoH === "disable_doh") {
-      // Don't check for prefHasUserValue if policy is set to disable DoH
-      this.setSetting("skipHeuristicsCheck", true);
-    } else {
+    if (policyEnableDoH === "no_policy_set") {
       // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
       this.setSetting("skipHeuristicsCheck", false);
+    } else {
+      // Don't check for prefHasUserValue if policy is set to disable DoH
+      this.setSetting("skipHeuristicsCheck", true);
     }
     return;
   },

--- a/src/background.js
+++ b/src/background.js
@@ -241,9 +241,6 @@ const rollout = {
     if (policyEnableDoH === "enable_doh" || policyEnableDoH === "disable_doh") {
       // Don't check for prefHasUserValue if policy is set to disable DoH
       this.setSetting("skipHeuristicsCheck", true);
-    } else {
-      // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
-      this.setSetting("skipHeuristicsCheck", false);
     }
     return;
   },

--- a/src/experiments/heuristics/api.js
+++ b/src/experiments/heuristics/api.js
@@ -53,8 +53,8 @@ const heuristicsManager = {
     if (Services.policies.status === Services.policies.ACTIVE) {
       let policies = Services.policies.getActivePolicies();
       if (!("DNSOverHTTPS" in policies)) {
-        // If DoH isn't in the policy, disable it
-        return "disable_doh";
+        // If DoH isn't in the policy, return that there is a policy (but no DoH specifics)
+        return "policy_without_doh";
       } else {
         let dohPolicy = policies.DNSOverHTTPS;
         if (dohPolicy.Enabled === true) {

--- a/src/experiments/netChange/api.js
+++ b/src/experiments/netChange/api.js
@@ -35,7 +35,7 @@ var netChange = class netChange extends ExtensionAPI {
                 if (data === "changed" || data === "up") {
                   // Trigger the netChangeWaiting switch, initiating 5sec timeout 
                   netChangeWaiting = true;
-                  await sleep(5000);
+                  await sleep(60000);
                   if (gNetworkLinkService.linkStatusKnown && gNetworkLinkService.isLinkUp) {
                     fire.async(data);
                   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "0.0.11",
+  "version": "0.0.12",
 
   "hidden": true,
 


### PR DESCRIPTION
Fixed #94 

Also added additional logic to check Heuristics if a user had a policy set and then removed it.

To check, have a policy in place that disables DoH, run the addon and then reload the add-on. Before, it would only send one telemetry event. Now, it runs each time on "startup".

Also added logic to test for a policy set that doesn't reference DoH. Test it using this policy file: 
[policies-NoMentionDoH.json.zip](https://github.com/mozilla/doh-rollout/files/3697950/policies-NoMentionDoH.json.zip)


 