### PR TITLE
Fixed #138 - Added results to ping send for mismatched trr.mode

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -76,15 +76,16 @@ const stateManager = {
 
     if (prevMode !== curMode) {
       log("Mismatched, curMode: ", curMode);
+      // Cache results for Telemetry send, including setting eval reason
+      let results = await runHeuristics();
+      results.evaluateReason = "userModified";
       if (curMode === 0 || curMode === 5) {
         // If user has manually set trr.mode to 0, and it was previously something else.
-        let results = await runHeuristics();
-        results.evaluateReason = "userModified";
         browser.experiments.heuristics.sendHeuristicsPing("disable_doh", results);
         await stateManager.rememberDisableHeuristics();
       } else {
         // Check if trr.mode is not in default value.
-        await rollout.trrModePrefHasUserValue("shouldRunHeuristics_mismatch");
+        await rollout.trrModePrefHasUserValue("shouldRunHeuristics_mismatch", results);
       }
       return false;
     }


### PR DESCRIPTION
To test: 
- Run build
- Create bool pref `doh-rollout.enabled` to true
- Click "OK" on doorhanger
- Go to about:config
- `network.trr.mode` should be `2`. Change this to `3`.
- Change WiFi networks
- Wait 60-70s
- Check about:telemetry
- Should have telemetry event of "prefHasUserValue"