### PR TITLE
Add automatic signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,36 @@ version: 2.1
 orbs:
   jq: circleci/jq@1.9.0
 
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build:
+          name: build-non-tag
+          signProd: false
+          signStage: true
+
+      - build:
+          name: build-tag
+          signProd: true
+          signStage: false
+          filters:
+            # Run only on commits that have a tag
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.+/
+
 jobs:
   build:
+    parameters:
+      signProd:
+        type: boolean
+        default: false
+      signStage:
+        type: boolean
+        default: false
+
     docker:
       - image: circleci/node:10
 
@@ -32,5 +60,54 @@ jobs:
             BASE=$(basename dist/*.zip .zip)
             mv dist/$BASE.zip dist/$BASE.xpi
 
+      - when:
+          condition: << parameters.signStage >>
+          steps:
+            - sign-addon:
+                signingKey: AUTOGRAPH_STAGE_SIGNING_KEY
+                endpoint: https://edge.stage.autograph.services.mozaws.net/sign
+                suffix: "-testing"
+
+      - when:
+          condition: << parameters.signProd >>
+          steps:
+            - sign-addon:
+                signingKey: AUTOGRAPH_PROD_SIGNING_KEY
+                endpoint: https://edge.prod.autograph.services.mozaws.net/sign
+
       - store_artifacts:
           path: dist
+
+commands:
+  sign-addon:
+    description: "Invoke Autograph to sign the extension"
+    parameters:
+      signingKey:
+        type: env_var_name
+      endpoint:
+        type: string
+      suffix:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Signing add-on
+          command: |
+            if [[ -z "${<< parameters.signingKey >>}" ]]; then
+              echo 'Signing key not provided'
+              exit 1
+            fi
+            BASE=$(basename dist/*.xpi .xpi)
+            UNSIGNED="dist/${BASE}.xpi"
+            SIGNED="dist/${BASE}-signed<< parameters.suffix >>.xpi"
+            curl -F "input=@$UNSIGNED" -o $SIGNED \
+              -H "Authorization: ${<< parameters.signingKey >>}" \
+              << parameters.endpoint >>
+            # check that Autograph at least returned a zip file (instead of an error)
+            if ! file $SIGNED | grep -i zip > /dev/null; then
+              echo "Autograph did not return a valid signed extension"
+              if file $SIGNED | grep -i text > /dev/null; then
+                cat $SIGNED
+              fi
+              exit 1
+            fi


### PR DESCRIPTION
This should result in CircleCI artifacts being created for each commit that has CI run on it. Tags will get "production" signatures, suitable for internal testing. Normal master commits and PRs will get "staging" signatures, suitable for testing by devs and QA.