### PR TITLE
Fixed #156 – Removed disable call from setup function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -364,9 +364,9 @@ const setup = {
 
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
-      log("Disabling"); 
+      // DoH status will not be modified from whatever the current setting is at runtime
+      log("Addon has been disabled. DoH status will not be modified from current setting");
       browser.storage.local.clear();
-      await stateManager.setState("disabled");
       await stateManager.rememberDisableHeuristics();
       return;
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "1.0.3",
+  "version": "1.0.4",
 
   "hidden": true,
 


### PR DESCRIPTION
Expected behavior: If user modifies trr.mode **after** being enabled, the add-on will send one telemtery event the next restart/network change event ONCE and then never run again. 

Below runs through scenario where user updates `network.trr.mode` after some time DoH being enabled. 

- Start add-on, enable DoH
- Expected: `network.trr.mode` to be `2`, telemetry event to `enable_doh` 
- Restart/network change
- Expected: `network.trr.mode` to be `2`, telemetry event to `enable_doh` 
- Go to about:preferences and uncheck DoH
- Expected: `network.trr.mode` to be `0`, no telemetry event 
- Restart/network change
- Expected: `network.trr.mode` to be `0`, telemetry event to `disable_doh`
- Restart/network change
- Expected: `network.trr.mode` to be `0`, no telemetry events
- Go to about:preferences and check DoH
- Expected: `network.trr.mode` to be `2`, no telemetry events
- Restart/network change
- Expected: `network.trr.mode` to be `2`, no telemetry events