### PR TITLE
v1.1 Release PR 

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -16,6 +16,10 @@ const TRR_MODE_PREF = "network.trr.mode";
 // of "doh-rollout.enabled". Note that instead of setting it to false, it is cleared.
 const DOH_SELF_ENABLED_PREF = "doh-rollout.self-enabled";
 
+// This pref is set once a migration function has ran, updating local storage items to the
+// new doh-rollot.X namespace. This applies to both `doneFirstRun` and `skipHeuristicsCheck`. 
+const DOH_BALROG_MIGRATION_PREF = "doh-rollout.balrog-migration";
+
 const stateManager = {
   async setState(state) {
     log("setState: ", state);
@@ -310,8 +314,29 @@ const rollout = {
 
   },
 
+  async migrateLocalStoragePrefs() {
+    if (await this.getSetting("doneFirstRun")){
+      await this.setSetting("doh-rollout.doneFirstRun");
+    }
+
+    if (await this.getSetting("skipHeuristicsCheck")){
+      await this.setSetting("doh-rollout.skipHeuristicsCheck");
+    }
+
+    // Set pref to skip this function in the future.
+    browser.experiments.preferences.setBoolPref(DOH_BALROG_MIGRATION_PREF, true);
+
+  },
+
   async init() {
     log("calling init");
+
+    // Migrate updated local storage item names. If this has already been done once, it will be skipped.
+    const isMigrated = await browser.experiments.preferences.getBoolPref(DOH_BALROG_MIGRATION_PREF, false);
+
+    if (!isMigrated) {
+      await this.migrateLocalStoragePrefs();
+    }
 
     // Check if the add-on has run before
     let doneFirstRun = await this.getSetting("doh-rollout.doneFirstRun");

--- a/src/background.js
+++ b/src/background.js
@@ -442,6 +442,7 @@ const setup = {
     if (isAddonDisabled || remoteDisableAddon) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
       // DoH status will not be modified from whatever the current setting is at runtime
+      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       log("Addon has been disabled. DoH status will not be modified from current setting");
       browser.storage.local.clear();
       await stateManager.rememberDisableHeuristics();

--- a/src/background.js
+++ b/src/background.js
@@ -10,6 +10,10 @@ function log() {
 }
 
 const TRR_MODE_PREF = "network.trr.mode";
+
+// This preference is set to TRUE when DoH has been enabled via the add-on. It will
+// allow the add-on to continue to function without the aid of the Normandy-triggered pref
+// of "doh-rollout.enabled". Note that instead of setting it to false, it is cleared.
 const DOH_SELF_ENABLED_PREF = "doh-rollout.self-enabled";
 
 const stateManager = {
@@ -22,10 +26,10 @@ const stateManager = {
       break;
     case "disabled":
       browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 0);
-      browser.experiments.preferences.setBoolPref(DOH_SELF_ENABLED_PREF, false);
+      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     case "manuallyDisabled":
-      browser.experiments.preferences.setBoolPref(DOH_SELF_ENABLED_PREF, false);
+      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     case "UIOk":
       browser.experiments.preferences.setBoolPref(DOH_SELF_ENABLED_PREF, true);
@@ -36,7 +40,7 @@ const stateManager = {
       break;
     case "UIDisabled":
       browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 5);
-      browser.experiments.preferences.setBoolPref(DOH_SELF_ENABLED_PREF, false);
+      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -15,6 +15,23 @@ const stateManager = {
   async setState(state) {
     log("setState: ", state);
     browser.experiments.preferences.state.set({ value: state });
+
+    switch (state) {
+    case "uninstalled":
+      break;
+    case "disabled":
+      break;
+    case "manuallyDisabled":
+      break;
+    case "UIOk":
+    case "enabled":
+      browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 2);
+      break;
+    case "UIDisabled":
+      browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 5);
+      break;
+    }
+
     await browser.experiments.heuristics.sendStatePing(state);
     await stateManager.rememberTRRMode();
   },

--- a/src/background.js
+++ b/src/background.js
@@ -416,7 +416,8 @@ const setup = {
         "doh-rollout.doorhanger-decision",
         "doh-rollout.doorhanger-shown",
         "doh-rollout.previous.trr.mode",
-        "doh-rollout.enabled"
+        "doh-rollout.enabled",
+        DOH_SELF_ENABLED_PREF
       ];
 
       for (const pref of addonPrefs) {

--- a/src/background.js
+++ b/src/background.js
@@ -26,7 +26,7 @@ const TRR_MODE_PREF = "network.trr.mode";
 // of "doh-rollout.enabled". Note that instead of setting it to false, it is cleared.
 const DOH_SELF_ENABLED_PREF = "doh-rollout.self-enabled";
 
-// This pref is part of a cache mechnaism to see if the heuristics dictated a change in the DoH settings
+// This pref is part of a cache mechanism to see if the heuristics dictated a change in the DoH settings
 const DOH_PREVIOUS_TRR_MODE_PREF = "doh-rollout.previous.trr.mode";
 
 // Set after doorhanger has been interacted with by the user
@@ -49,7 +49,6 @@ const stateManager = {
       break;
     case "disabled":
       rollout.setSetting(TRR_MODE_PREF, 0);
-      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     case "manuallyDisabled":
       browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);

--- a/src/background.js
+++ b/src/background.js
@@ -9,12 +9,38 @@ function log() {
   }
 }
 
+// Gate-keeping pref to run the add-on
+const DOH_ENABLED_PREF = "doh-rollout.enabled";
+
+// Pref that sets DoH to on/off. It has multiple modes:
+// 0: Off (default)
+// 1: null (No setting)
+// 2: Enabled, but will fall back to 0 on DNS lookup failure
+// 3: Always on.
+// 4: null (No setting)
+// 5: Never on.
 const TRR_MODE_PREF = "network.trr.mode";
 
 // This preference is set to TRUE when DoH has been enabled via the add-on. It will
 // allow the add-on to continue to function without the aid of the Normandy-triggered pref
 // of "doh-rollout.enabled". Note that instead of setting it to false, it is cleared.
 const DOH_SELF_ENABLED_PREF = "doh-rollout.self-enabled";
+
+// This pref is part of a cache mechnaism to see if the heuristics dictated a change in the DoH settings
+const DOH_PREVIOUS_TRR_MODE_PREF = "doh-rollout.previous.trr.mode";
+
+// Set after doorhanger has been interacted with by the user
+const DOH_DOORHANGER_SHOWN_PREF = "doh-rollout.doorhanger-shown";
+
+// Records if the user opted in/out of DoH study by clicking on doorhanger
+const DOH_DOORHANGER_USER_DECISION_PREF = "doh-rollout.doorhanger-decision";
+
+// Records if user has decided to opt out of study, either by disabling via the doorhanger,
+// unchecking "DNS-over-HTTPS" with about:preferences, or manually setting network.trr.mode
+const DOH_DISABLED_PREF = "doh-rollout.disable-heuristics";
+
+// Pref that will clean up after the add-on in case of emergency.
+const DOH_REMOTE_DISABLE_PREF = "doh-rollout.remote-disable";
 
 const stateManager = {
   async setState(state) {
@@ -25,21 +51,21 @@ const stateManager = {
     case "uninstalled":
       break;
     case "disabled":
-      browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 0);
+      rollout.setSetting(TRR_MODE_PREF, 0);
       browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     case "manuallyDisabled":
       browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     case "UIOk":
-      browser.experiments.preferences.setBoolPref(DOH_SELF_ENABLED_PREF, true);
+      rollout.setSetting(DOH_SELF_ENABLED_PREF, true);
       break;
     case "enabled":
-      browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 2);
-      browser.experiments.preferences.setBoolPref(DOH_SELF_ENABLED_PREF, true);
+      rollout.setSetting(TRR_MODE_PREF, 2);
+      rollout.setSetting(DOH_SELF_ENABLED_PREF, true);
       break;
     case "UIDisabled":
-      browser.experiments.preferences.setIntPref(TRR_MODE_PREF, 5);
+      rollout.setSetting(TRR_MODE_PREF, 5);
       browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       break;
     }
@@ -51,42 +77,36 @@ const stateManager = {
   async rememberTRRMode() {
     let curMode = await browser.experiments.preferences.getIntPref(TRR_MODE_PREF, 0);
     log("Saving current trr mode:", curMode);
-    await rollout.setSetting("doh-rollout.previous.trr.mode", curMode, true);
+    await rollout.setSetting(DOH_PREVIOUS_TRR_MODE_PREF, curMode, true);
   },
 
   async rememberDoorhangerShown() {
     // This will be shown on startup and netChange events until a user clicks
     // to confirm/disable DoH or presses the esc key (confirming)
     log("Remembering that doorhanger has been shown");
-    await rollout.setSetting("doh-rollout.doorhanger-shown", true, true);
-  },
-
-  async rememberDoorhangerPingSent() {
-    log("Remembering that doorhanger ping has been sent");
-    await rollout.setSetting("doh-rollout.doorhanger-ping-sent", true);
+    await rollout.setSetting(DOH_DOORHANGER_SHOWN_PREF, true);
   },
 
   async rememberDoorhangerDecision(decision) {
     log("Remember doorhanger decision:", decision);
-    await rollout.setSetting("doh-rollout.doorhanger-decision", decision, true);
-
+    await rollout.setSetting(DOH_DOORHANGER_USER_DECISION_PREF, decision, true);
   },
 
   async rememberDisableHeuristics() {
     log("Remembering to never run heuristics again");
-    await rollout.setSetting("doh-rollout.disable-heuristics", true, true);
+    await rollout.setSetting(DOH_DISABLED_PREF, true);
   },
 
   async shouldRunHeuristics() {
     // Check if heuristics has been disabled from rememberDisableHeuristics()
-    let disableHeuristics = await rollout.getSetting("doh-rollout.disable-heuristics", false);
+    let disableHeuristics = await rollout.getSetting(DOH_DISABLED_PREF, false);
     if (disableHeuristics) {
       // Do not modify DoH for this user.
       log("disableHeuristics has been enabled.");
       return false;
     }
 
-    let prevMode = await rollout.getSetting("doh-rollout.previous.trr.mode", 0);
+    let prevMode = await rollout.getSetting(DOH_PREVIOUS_TRR_MODE_PREF, 0);
     let curMode = await browser.experiments.preferences.getIntPref(
       TRR_MODE_PREF, 0);
 
@@ -125,7 +145,7 @@ const stateManager = {
   },
 
   async shouldShowDoorhanger() {
-    let doorhangerShown = await rollout.getSetting("doh-rollout.doorhanger-shown", false);
+    let doorhangerShown = await rollout.getSetting(DOH_DOORHANGER_SHOWN_PREF, false);
     log("Should show doorhanger:", !doorhangerShown);
     return !doorhangerShown;
   },
@@ -162,7 +182,6 @@ const rollout = {
     log("Doorhanger accepted on tab", tabId);
     await stateManager.setState("UIOk");
     await stateManager.rememberDoorhangerDecision("UIOk");
-    await stateManager.rememberDoorhangerPingSent();
     await stateManager.rememberDoorhangerShown();
   },
 
@@ -170,7 +189,6 @@ const rollout = {
     log("Doorhanger declined on tab", tabId);
     await stateManager.setState("UIDisabled");
     await stateManager.rememberDoorhangerDecision("UIDisabled");
-    await stateManager.rememberDoorhangerPingSent();
     let results = await runHeuristics();
     results.evaluateReason = "doorhangerDecline";
     browser.experiments.heuristics.sendHeuristicsPing("disable_doh", results);
@@ -218,34 +236,46 @@ const rollout = {
   },
 
   async getSetting(name, defaultValue) {
-    let data = await browser.storage.local.get(name);
-    let value = data[name];
-    if (value === undefined) {
-      return defaultValue;
+
+    if (defaultValue === undefined){
+      throw new Error(`Missing defaultValue argument when trying to fetch pref: ${JSON.stringify(name)}`);
     }
-    return data[name];
+
+    switch (typeof defaultValue) {
+    case "boolean":
+      log("boolean", name, await browser.experiments.preferences.getBoolPref(name, defaultValue));
+      return await browser.experiments.preferences.getBoolPref(name, defaultValue);
+    case "number":
+      log("bumber", name, await browser.experiments.preferences.getIntPref(name, defaultValue));
+      return await browser.experiments.preferences.getIntPref(name, defaultValue);
+    case "string":
+      log("btring", name, await browser.experiments.preferences.getCharPref(name, defaultValue));
+      return await browser.experiments.preferences.getCharPref(name, defaultValue);
+    }
   },
 
-  async setSetting(name, value, makeDurable) {
-    await browser.storage.local.set({[name]: value});
 
-    // makeDurable is bool arg that sets same local storage item as durable pref
-    // (controlled outside of Extension Preference Manager)
-    if (!makeDurable) {
-      return;
-    }
-
+  /**
+   * Exposed
+   *
+   * @param  {type} name  description
+   * @param  {type} value description
+   * @return {type}       description
+   */
+  async setSetting(name, value) {
     // Based on type of pref, set pref accordingly
     switch (typeof value) {
     case "boolean":
-      browser.experiments.preferences.setBoolPref(name, value);
+      await browser.experiments.preferences.setBoolPref(name, value);
       break;
     case "number":
-      browser.experiments.preferences.setIntPref(name, value);
+      await browser.experiments.preferences.setIntPref(name, value);
       break;
     case "string":
-      browser.experiments.preferences.setCharPref(name, value);
+      await browser.experiments.preferences.setCharPref(name, value);
       break;
+    default:
+      throw new Error("setSetting typeof value unknown!");
     }
   },
 
@@ -254,7 +284,7 @@ const rollout = {
     results.evaluateReason = event;
 
     // Reset skipHeuristicsCheck
-    this.setSetting("skipHeuristicsCheck", false);
+    await rollout.setSetting("doh-rollout.skipHeuristicsCheck", false);
 
     // This confirms if a user has modified DoH (via the TRR_MODE_PREF) outside of the addon
     // This runs only on the FIRST time that add-on is enabled and if the stored pref
@@ -276,7 +306,7 @@ const rollout = {
     results.evaluateReason = event;
 
     // Reset skipHeuristicsCheck
-    this.setSetting("skipHeuristicsCheck", false);
+    await rollout.setSetting("doh-rollout.skipHeuristicsCheck", false);
 
     // Check for Policies before running the rest of the heuristics
     let policyEnableDoH = await browser.experiments.heuristics.checkEnterprisePolicies();
@@ -301,10 +331,10 @@ const rollout = {
     // Determine to skip additional heuristics (by presence of an enterprise policy)
     if (policyEnableDoH === "no_policy_set") {
       // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
-      this.setSetting("skipHeuristicsCheck", false);
+      await rollout.setSetting("doh-rollout.skipHeuristicsCheck", false);
     } else {
       // Don't check for prefHasUserValue if policy is set to disable DoH
-      this.setSetting("skipHeuristicsCheck", true);
+      await rollout.setSetting("doh-rollout.skipHeuristicsCheck", true);
     }
     return;
 
@@ -314,7 +344,7 @@ const rollout = {
     log("calling init");
 
     // Check if the add-on has run before
-    let doneFirstRun = await this.getSetting("doneFirstRun");
+    let doneFirstRun = await rollout.getSetting("doh-rollout.doneFirstRun", false);
 
     // Register the events for sending pings
     browser.experiments.heuristics.setupTelemetry();
@@ -324,7 +354,7 @@ const rollout = {
 
     if (!doneFirstRun) {
       log("first run!");
-      this.setSetting("doneFirstRun", true);
+      await rollout.setSetting("doh-rollout.doneFirstRun", true);
       // Check if user has a set a custom pref only on first run, not on each startup
       await this.trrModePrefHasUserValue("first_run", results);
       await this.enterprisePolicyCheck("first_run", results);
@@ -334,7 +364,7 @@ const rollout = {
     }
 
     // Only run the heuristics if user hasn't explicitly enabled/disabled DoH
-    let skipHeuristicsCheck = await this.getSetting("skipHeuristicsCheck");
+    let skipHeuristicsCheck = await rollout.getSetting("doh-rollout.skipHeuristicsCheck", false);
     log("skipHeuristicsCheck: ", skipHeuristicsCheck);
 
     if (!skipHeuristicsCheck) {
@@ -408,24 +438,25 @@ const rollout = {
 
 const setup = {
   async start() {
-    const isAddonDisabled = await rollout.getSetting("doh-rollout.disable-heuristics", false);
-    const runAddonPref = await browser.experiments.preferences.getBoolPref("doh-rollout.enabled", false);
-    const runAddonBypassPref = await browser.experiments.preferences.getBoolPref("doh-rollout.self-enabled", false);
-    const runAddonLocalStorage = await rollout.getSetting("doh-rollout.doorhanger-decision", false);
-    const remoteDisableAddon = await browser.experiments.preferences.getBoolPref("doh-rollout.remote-disable", false);
+    const isAddonDisabled = await rollout.getSetting(DOH_DISABLED_PREF, false);
+    const runAddonPref = await rollout.getSetting(DOH_ENABLED_PREF, false);
+    const runAddonBypassPref = await rollout.getSetting(DOH_SELF_ENABLED_PREF, false);
+    const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, false);
+    const remoteDisableAddon = await rollout.getSetting(DOH_REMOTE_DISABLE_PREF, false);
+
+    log(runAddonPref);
 
     if (isAddonDisabled || remoteDisableAddon) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
       // DoH status will not be modified from whatever the current setting is at runtime
       browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       log("Addon has been disabled. DoH status will not be modified from current setting");
-      browser.storage.local.clear();
       await stateManager.rememberDisableHeuristics();
       return;
     }
 
-    if (runAddonPref || runAddonBypassPref || runAddonLocalStorage === "UIOk" || runAddonLocalStorage === "enabled") {
-      // Confirms that the Normand/default branch gate keeping pref is set to true
+    if (runAddonPref || runAddonBypassPref || runAddonDoorhangerDecision === "UIOk" || runAddonDoorhangerDecision === "enabled") {
+      // Confirms that the Normandy/default branch gate keeping pref is set to true
       rollout.init();
     } else {
       log("First run");

--- a/src/background.js
+++ b/src/background.js
@@ -414,27 +414,7 @@ const setup = {
     const runAddonLocalStorage = await rollout.getSetting("doh-rollout.doorhanger-decision", false);
     const remoteDisableAddon = await browser.experiments.preferences.getBoolPref("doh-rollout.remote-disable", false);
 
-    if (remoteDisableAddon) {
-      // Fail safe to remotely disable add-on.
-      const addonPrefs = [
-        "doh-rollout.doorhanger-decision",
-        "doh-rollout.doorhanger-shown",
-        "doh-rollout.previous.trr.mode",
-        "doh-rollout.enabled",
-        DOH_SELF_ENABLED_PREF
-      ];
-
-      for (const pref of addonPrefs) {
-        browser.experiments.preferences.clearUserPref(pref);
-      }
-
-      browser.storage.local.clear();
-      await stateManager.rememberDisableHeuristics();
-
-      return;
-    }
-
-    if (isAddonDisabled) {
+    if (isAddonDisabled || remoteDisableAddon) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
       // DoH status will not be modified from whatever the current setting is at runtime
       log("Addon has been disabled. DoH status will not be modified from current setting");

--- a/src/background.js
+++ b/src/background.js
@@ -39,9 +39,6 @@ const DOH_DOORHANGER_USER_DECISION_PREF = "doh-rollout.doorhanger-decision";
 // unchecking "DNS-over-HTTPS" with about:preferences, or manually setting network.trr.mode
 const DOH_DISABLED_PREF = "doh-rollout.disable-heuristics";
 
-// Pref that will clean up after the add-on in case of emergency.
-const DOH_REMOTE_DISABLE_PREF = "doh-rollout.remote-disable";
-
 const stateManager = {
   async setState(state) {
     log("setState: ", state);
@@ -442,11 +439,10 @@ const setup = {
     const runAddonPref = await rollout.getSetting(DOH_ENABLED_PREF, false);
     const runAddonBypassPref = await rollout.getSetting(DOH_SELF_ENABLED_PREF, false);
     const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, false);
-    const remoteDisableAddon = await rollout.getSetting(DOH_REMOTE_DISABLE_PREF, false);
 
     log(runAddonPref);
 
-    if (isAddonDisabled || remoteDisableAddon) {
+    if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
       // DoH status will not be modified from whatever the current setting is at runtime
       browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -65,8 +65,10 @@ var preferences = class preferences extends ExtensionAPI {
                 fire.async();
               };
               Services.prefs.addObserver("doh-rollout.enabled", observer);
+              Services.prefs.addObserver("doh-rollout.remote-disable", observer);
               return () => {
                 Services.prefs.removeObserver("doh-rollout.enabled", observer);
+                Services.prefs.removeObserver("doh-rollout.remote-disable", observer);
               };
             },
           }).api(),

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -13,7 +13,6 @@ Cu2.import("resource://gre/modules/ExtensionPreferencesManager.jsm");
 
 const TRR_URI_PREF = "network.trr.uri";
 const TRR_DISABLE_ECS_PREF = "network.trr.disable-ECS";
-const TRR_MODE_PREF = "network.trr.mode";
 
 ExtensionPreferencesManager.addSetting("dohRollout.state", {
   prefNames: [
@@ -21,7 +20,7 @@ ExtensionPreferencesManager.addSetting("dohRollout.state", {
     TRR_DISABLE_ECS_PREF,
   ],
 
-  setCallback(value) {
+  setCallback() {
     let prefs = {};
     prefs[TRR_URI_PREF] = "https://mozilla.cloudflare-dns.com/dns-query";
     prefs[TRR_DISABLE_ECS_PREF] = true;

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -46,6 +46,9 @@ var preferences = class preferences extends ExtensionAPI {
           async setBoolPref(name, defaultValue) {
             return Services.prefs.setBoolPref(name, defaultValue);
           },
+          async getCharPref(name, defaultValue) {
+            return Services.prefs.getCharPref(name, defaultValue);
+          },
           async setCharPref(name, defaultValue) {
             return Services.prefs.setCharPref(name, defaultValue);
           },

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -43,6 +43,12 @@ var preferences = class preferences extends ExtensionAPI {
           async getBoolPref(name, defaultValue) {
             return Services.prefs.getBoolPref(name, defaultValue);
           },
+          async setBoolPref(name, defaultValue) {
+            return Services.prefs.setBoolPref(name, defaultValue);
+          },
+          async setCharPref(name, defaultValue) {
+            return Services.prefs.setCharPref(name, defaultValue);
+          },
           async prefHasUserValue(name) {
             return Services.prefs.prefHasUserValue(name);
           },

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -19,30 +19,12 @@ ExtensionPreferencesManager.addSetting("dohRollout.state", {
   prefNames: [
     TRR_URI_PREF,
     TRR_DISABLE_ECS_PREF,
-    TRR_MODE_PREF,
   ],
 
   setCallback(value) {
     let prefs = {};
     prefs[TRR_URI_PREF] = "https://mozilla.cloudflare-dns.com/dns-query";
     prefs[TRR_DISABLE_ECS_PREF] = true;
-    prefs[TRR_MODE_PREF] = 0;
-
-    switch (value) {
-    case "uninstalled":
-      break;
-    case "disabled":
-      break;
-    case "manuallyDisabled":
-      break;
-    case "UIOk":
-    case "enabled":
-      prefs[TRR_MODE_PREF] = 2;
-      break;
-    case "UIDisabled":
-      prefs[TRR_MODE_PREF] = 5;
-      break;
-    }
     return prefs;
   },
 });
@@ -56,12 +38,16 @@ var preferences = class preferences extends ExtensionAPI {
           async getIntPref(name, defaultValue) {
             return Services.prefs.getIntPref(name, defaultValue);
           },
+          async setIntPref(name, defaultValue) {
+            return Services.prefs.setIntPref(name, defaultValue);
+          },
           async getBoolPref(name, defaultValue) {
             return Services.prefs.getBoolPref(name, defaultValue);
           },
           async prefHasUserValue(name) {
             return Services.prefs.prefHasUserValue(name);
           },
+
 
           onPrefChanged: new EventManager({
             context,

--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -49,6 +49,9 @@ var preferences = class preferences extends ExtensionAPI {
           async setCharPref(name, defaultValue) {
             return Services.prefs.setCharPref(name, defaultValue);
           },
+          async clearUserPref(name) {
+            return Services.prefs.clearUserPref(name);
+          },
           async prefHasUserValue(name) {
             return Services.prefs.prefHasUserValue(name);
           },

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -174,7 +174,9 @@
         "parameters": [
           {
             "type": "string",
-            "name": "name"
+            "name": {
+              "enum": ["doh-rollout.self-enabled"]
+            }
           }
         ],
         "async": true

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -162,6 +162,18 @@
         "async": true
       },
       {
+        "name": "clearUserPref",
+        "type": "function",
+        "description": "Resets value of prefence back to default",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "name"
+          }
+        ],
+        "async": true
+      },
+      {
         "name": "prefHasUserValue",
         "type": "function",
         "description": "Check if the user has set a value of a preference",

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -150,6 +150,24 @@
         "async": true
       },
       {
+        "name": "getCharPref",
+        "type": "function",
+        "description": "Gets the value of a string preference",
+        "parameters": [
+          {
+            "type": "string",
+            "name": {
+              "enum": ["doh-rollout.doorhanger-decision"]
+            }
+          },
+          {
+            "type": "string",
+            "name": "defaultValue"
+          }
+        ],
+        "async": true
+      },
+      {
         "name": "setCharPref",
         "type": "function",
         "description": "Sets the value of a string preference",

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -139,7 +139,7 @@
           {
             "type": "string",
             "name": {
-              "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.balrog-migration", "doh-rollout.disable-heuristics"]
+              "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.disable-heuristics"]
             }
           },
           {

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -104,9 +104,7 @@
         "parameters": [
           {
             "type": "string",
-            "name": {
-              "enum": ["network.trr.mode", "doh-rollout.previous.trr.mode"]
-            }
+            "enum": ["network.trr.mode", "doh-rollout.previous.trr.mode"]
           },
           {
             "type": "integer",
@@ -138,9 +136,7 @@
         "parameters": [
           {
             "type": "string",
-            "name": {
-              "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.disable-heuristics"]
-            }
+            "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.disable-heuristics", "doh-rollout.doneFirstRun", "doh-rollout.skipHeuristicsCheck"]
           },
           {
             "type": "boolean",
@@ -156,9 +152,7 @@
         "parameters": [
           {
             "type": "string",
-            "name": {
-              "enum": ["doh-rollout.doorhanger-decision"]
-            }
+            "enum": ["doh-rollout.doorhanger-decision"]
           },
           {
             "type": "string",
@@ -174,9 +168,7 @@
         "parameters": [
           {
             "type": "string",
-            "name": {
-              "enum": ["doh-rollout.doorhanger-decision"]
-            }
+            "enum": ["doh-rollout.doorhanger-decision"]
           },
           {
             "type": "string",
@@ -192,9 +184,7 @@
         "parameters": [
           {
             "type": "string",
-            "name": {
-              "enum": ["doh-rollout.self-enabled"]
-            }
+            "enum": ["doh-rollout.self-enabled"]
           }
         ],
         "async": true

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -104,7 +104,9 @@
         "parameters": [
           {
             "type": "string",
-            "name": "name"
+            "name": {
+              "enum": ["network.trr.mode", "doh-rollout.previous.trr.mode"]
+            }
           },
           {
             "type": "integer",
@@ -136,7 +138,9 @@
         "parameters": [
           {
             "type": "string",
-            "name": "name"
+            "name": {
+              "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.balrog-migration", "doh-rollout.disable-heuristics"]
+            }
           },
           {
             "type": "boolean",
@@ -152,7 +156,9 @@
         "parameters": [
           {
             "type": "string",
-            "name": "name"
+            "name": {
+              "enum": ["doh-rollout.doorhanger-decision"]
+            }
           },
           {
             "type": "string",

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -130,6 +130,38 @@
         "async": true
       },
       {
+        "name": "setBoolPref",
+        "type": "function",
+        "description": "Sets the value of a boolean preference",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "name"
+          },
+          {
+            "type": "boolean",
+            "name": "defaultValue"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "setCharPref",
+        "type": "function",
+        "description": "Sets the value of a string preference",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "name"
+          },
+          {
+            "type": "string",
+            "name": "defaultValue"
+          }
+        ],
+        "async": true
+      },
+      {
         "name": "prefHasUserValue",
         "type": "function",
         "description": "Check if the user has set a value of a preference",

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -98,6 +98,22 @@
         "async": true
       },
       {
+        "name": "setIntPref",
+        "type": "function",
+        "description": "Sets the value of a integer preference",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "name"
+          },
+          {
+            "type": "integer",
+            "name": "defaultValue"
+          }
+        ],
+        "async": true
+      },
+      {
         "name": "getBoolPref",
         "type": "function",
         "description": "Get the value of a boolean preference",


### PR DESCRIPTION
## Summary

This PR adds the required features for the v1.1 release. 

Fixes #169, Fixes #170 

### Features: 

- Set prefs via `Services.prefs` instead of the Extension Preferences Module. These make prefs set this way "durable" (which do not get removed on proper add-on install). This sets the following prefs in this manner. By setting them this way, in the future, we can detect DoH settings during the roll out and respect user choice. 
  - "doh-rollout.doorhanger-decision",
  - "doh-rollout.doorhanger-shown",
  - "doh-rollout.previous.trr.mode",
- During Setup function, read local storage data to turn add on (by passing `doh-rollout.enabled` pref). 
- During Setup function, check for fail safe preference (`doh-rollout.remote-disable`). If true, clear all other prefs, local storage and never run again. Note that this preference does not get set any where and can only be flipped via Normandy. 
- After running correctly and enabling DoH, a durable pref (`doh-rollout.self-enabled`) is set. If DoH is disabled, this is flipped to false. This feature will allow the add-on to run without the aid of Normandy for users after running the first time.

## Testing

This will request testing for the following scenarios: 
- User had add-on installed and enabled, and then removed add-on from machine. Reinstall add-on and it should run WITHOUT adding the `doh-rollout.enabled` pref 
- Instance where the add-on need to be completely disabled. Set a pref of `doh-rollout.remote-disable` to true via Normandy. 
- Instance where Normandy no longer is flipping the `doh-rollout.enabled` and local storage is wiped. The `doh-rollout.self-enabled` pref will continue to run the add-on as normal. 

