### PR TITLE
Fixed #174 - Added migration function for v.1.0.4 study participants 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "1.1.0",
+	"version": "1.2.0rc1",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -373,8 +373,9 @@ const rollout = {
       return;
     }
 
-    // Check all local items, and migrate them to prefs. If no value set, ignore them.
-    const localStorageItems = [
+    // Check all local storage keys from v1.0.4 users and migrate them to prefs.
+    // This only applies to keys that have a value.
+    const legacyLocalStorageKeys = [
       "doneFirstRun",
       "skipHeuristicsCheck",
       DOH_ENABLED_PREF,
@@ -388,7 +389,7 @@ const rollout = {
       DOH_DONE_FIRST_RUN_PREF
     ];
 
-    for (let item of localStorageItems) {
+    for (let item of legacyLocalStorageKeys) {
       let data = await browser.storage.local.get(item);
       let value = data[item];
 

--- a/src/background.js
+++ b/src/background.js
@@ -39,6 +39,14 @@ const DOH_DOORHANGER_USER_DECISION_PREF = "doh-rollout.doorhanger-decision";
 // unchecking "DNS-over-HTTPS" with about:preferences, or manually setting network.trr.mode
 const DOH_DISABLED_PREF = "doh-rollout.disable-heuristics";
 
+// Set to true when a user has ANY enterprise policy set, making sure to not run
+// heuristics, overwritting the policy.
+const DOH_SKIP_HEURISTICS_PREF = "doh-rollout.skipHeuristicsCheck";
+
+// Records when the add-on has been run once. This is in place to only check
+// network.trr.mode for prefHasUserValue on first run.
+const DOH_DONE_FIRST_RUN_PREF = "doh-rollout.doneFirstRun";
+
 // This pref is set once a migration function has ran, updating local storage items to the
 // new doh-rollot.X namespace. This applies to both `doneFirstRun` and `skipHeuristicsCheck`.
 const DOH_BALROG_MIGRATION_PREF = "doh-rollout.balrog-migration-done";
@@ -284,7 +292,7 @@ const rollout = {
     results.evaluateReason = event;
 
     // Reset skipHeuristicsCheck
-    await rollout.setSetting("doh-rollout.skipHeuristicsCheck", false);
+    await rollout.setSetting(DOH_SKIP_HEURISTICS_PREF, false);
 
     // This confirms if a user has modified DoH (via the TRR_MODE_PREF) outside of the addon
     // This runs only on the FIRST time that add-on is enabled and if the stored pref
@@ -306,7 +314,7 @@ const rollout = {
     results.evaluateReason = event;
 
     // Reset skipHeuristicsCheck
-    await rollout.setSetting("doh-rollout.skipHeuristicsCheck", false);
+    await rollout.setSetting(DOH_SKIP_HEURISTICS_PREF, false);
 
     // Check for Policies before running the rest of the heuristics
     let policyEnableDoH = await browser.experiments.heuristics.checkEnterprisePolicies();
@@ -331,10 +339,10 @@ const rollout = {
     // Determine to skip additional heuristics (by presence of an enterprise policy)
     if (policyEnableDoH === "no_policy_set") {
       // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
-      await rollout.setSetting("doh-rollout.skipHeuristicsCheck", false);
+      await rollout.setSetting(DOH_SKIP_HEURISTICS_PREF, false);
     } else {
       // Don't check for prefHasUserValue if policy is set to disable DoH
-      await rollout.setSetting("doh-rollout.skipHeuristicsCheck", true);
+      await rollout.setSetting(DOH_SKIP_HEURISTICS_PREF, true);
     }
     return;
 
@@ -349,7 +357,20 @@ const rollout = {
       return;
     }
 
-    const localStorageItems = ["doneFirstRun", "skipHeuristicsCheck"];
+    // Check all local items, and migrate them to prefs. If no value set, ignore them.
+    const localStorageItems = [
+      "doneFirstRun",
+      "skipHeuristicsCheck",
+      DOH_ENABLED_PREF,
+      TRR_MODE_PREF,
+      DOH_SELF_ENABLED_PREF,
+      DOH_PREVIOUS_TRR_MODE_PREF,
+      DOH_DOORHANGER_SHOWN_PREF,
+      DOH_DOORHANGER_USER_DECISION_PREF,
+      DOH_DISABLED_PREF,
+      DOH_SKIP_HEURISTICS_PREF,
+      DOH_DONE_FIRST_RUN_PREF
+    ];
 
     for (let item of localStorageItems) {
       let data = await browser.storage.local.get(item);
@@ -373,10 +394,8 @@ const rollout = {
   async init() {
     log("calling init");
 
-    await rollout.migrateLocalStoragePrefs();
-
     // Check if the add-on has run before
-    let doneFirstRun = await rollout.getSetting("doh-rollout.doneFirstRun", false);
+    let doneFirstRun = await rollout.getSetting(DOH_DONE_FIRST_RUN_PREF, false);
 
     // Register the events for sending pings
     browser.experiments.heuristics.setupTelemetry();
@@ -386,7 +405,7 @@ const rollout = {
 
     if (!doneFirstRun) {
       log("first run!");
-      await rollout.setSetting("doh-rollout.doneFirstRun", true);
+      await rollout.setSetting(DOH_DONE_FIRST_RUN_PREF, true);
       // Check if user has a set a custom pref only on first run, not on each startup
       await this.trrModePrefHasUserValue("first_run", results);
       await this.enterprisePolicyCheck("first_run", results);
@@ -396,7 +415,7 @@ const rollout = {
     }
 
     // Only run the heuristics if user hasn't explicitly enabled/disabled DoH
-    let skipHeuristicsCheck = await rollout.getSetting("doh-rollout.skipHeuristicsCheck", false);
+    let skipHeuristicsCheck = await rollout.getSetting(DOH_SKIP_HEURISTICS_PREF, false);
     log("skipHeuristicsCheck: ", skipHeuristicsCheck);
 
     if (!skipHeuristicsCheck) {
@@ -489,6 +508,9 @@ async function checkNormandyAddonStudy() {
 
 const setup = {
   async start() {
+    // Run Migration First, to continue to run rest of start up logic
+    await rollout.migrateLocalStoragePrefs();
+
     const isNormandyStudy = await checkNormandyAddonStudy();
     const isAddonDisabled = await rollout.getSetting(DOH_DISABLED_PREF, false);
     const runAddonPref = await rollout.getSetting(DOH_ENABLED_PREF, false);
@@ -496,6 +518,8 @@ const setup = {
     const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, false);
 
     log(runAddonPref);
+
+
 
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.

--- a/src/background.js
+++ b/src/background.js
@@ -532,13 +532,6 @@ const setup = {
     const runAddonBypassPref = await rollout.getSetting(DOH_SELF_ENABLED_PREF, false);
     const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, false);
 
-<<<<<<< HEAD
-    log(runAddonPref);
-
-
-
-=======
->>>>>>> master
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
       // DoH status will not be modified from whatever the current setting is at runtime

--- a/src/background.js
+++ b/src/background.js
@@ -369,6 +369,7 @@ const rollout = {
     const isMigrated = await browser.experiments.preferences.getBoolPref(DOH_BALROG_MIGRATION_PREF, false);
 
     if (isMigrated) {
+      log("User has been migrated.");
       return;
     }
 
@@ -391,19 +392,20 @@ const rollout = {
       let data = await browser.storage.local.get(item);
       let value = data[item];
 
-      let migratedName = name;
+      if (data.hasOwnProperty(item)) {
+        let migratedName = item;
 
-      if (!name.startsWith("doh-rollout.")){
-        migratedName = "doh-rollout." + name;
-      }
+        if (!item.startsWith("doh-rollout.")){
+          migratedName = "doh-rollout." + item;
+        }
 
-      if (value !== undefined) {
         await this.setSetting(migratedName, value);
       }
     }
 
     // Set pref to skip this function in the future.
     browser.experiments.preferences.setBoolPref(DOH_BALROG_MIGRATION_PREF, true);
+    log("Remembering that this user has been migrated.");
   },
 
   async init() {

--- a/src/background.js
+++ b/src/background.js
@@ -11,6 +11,10 @@ function log() {
 
 const TRR_MODE_PREF = "network.trr.mode";
 
+// This pref is set once a migration function has ran, updating local storage items to the
+// new doh-rollot.X namespace. This applies to both `doneFirstRun` and `skipHeuristicsCheck`.
+const DOH_BALROG_MIGRATION_PREF = "doh-rollout.balrog-migration-done";
+
 const stateManager = {
   async setState(state) {
     log("setState: ", state);
@@ -205,7 +209,7 @@ const rollout = {
     results.evaluateReason = event;
 
     // Reset skipHeuristicsCheck
-    this.setSetting("skipHeuristicsCheck", false);
+    this.setSetting("doh-rollout.skipHeuristicsCheck", false);
 
     // This confirms if a user has modified DoH (via the TRR_MODE_PREF) outside of the addon
     // This runs only on the FIRST time that add-on is enabled and if the stored pref
@@ -227,7 +231,7 @@ const rollout = {
     results.evaluateReason = event;
 
     // Reset skipHeuristicsCheck
-    this.setSetting("skipHeuristicsCheck", false);
+    this.setSetting("doh-rollout.skipHeuristicsCheck", false);
 
     // Check for Policies before running the rest of the heuristics
     let policyEnableDoH = await browser.experiments.heuristics.checkEnterprisePolicies();
@@ -252,20 +256,40 @@ const rollout = {
     // Determine to skip additional heuristics (by presence of an enterprise policy)
     if (policyEnableDoH === "no_policy_set") {
       // Resetting skipHeuristicsCheck in case a user had a policy and then removed it!
-      this.setSetting("skipHeuristicsCheck", false);
+      this.setSetting("doh-rollout.skipHeuristicsCheck", false);
     } else {
       // Don't check for prefHasUserValue if policy is set to disable DoH
-      this.setSetting("skipHeuristicsCheck", true);
+      this.setSetting("doh-rollout.skipHeuristicsCheck", true);
     }
     return;
 
   },
 
+  async migrateLocalStoragePrefs() {
+    if (await this.getSetting("doneFirstRun")){
+      await this.setSetting("doh-rollout.doneFirstRun");
+    }
+
+    if (await this.getSetting("skipHeuristicsCheck")){
+      await this.setSetting("doh-rollout.skipHeuristicsCheck");
+    }
+
+    // Set pref to skip this function in the future.
+    browser.experiments.preferences.setBoolPref(DOH_BALROG_MIGRATION_PREF, true);
+  },
+
   async init() {
     log("calling init");
 
+    // Migrate updated local storage item names. If this has already been done once, it will be skipped.
+    const isMigrated = await browser.experiments.preferences.getBoolPref(DOH_BALROG_MIGRATION_PREF, false);
+
+    if (!isMigrated) {
+      await this.migrateLocalStoragePrefs();
+    }
+
     // Check if the add-on has run before
-    let doneFirstRun = await this.getSetting("doneFirstRun");
+    let doneFirstRun = await this.getSetting("doh-rollout.doneFirstRun");
 
     // Register the events for sending pings
     browser.experiments.heuristics.setupTelemetry();
@@ -275,7 +299,7 @@ const rollout = {
 
     if (!doneFirstRun) {
       log("first run!");
-      this.setSetting("doneFirstRun", true);
+      this.setSetting("doh-rollout.doneFirstRun", true);
       // Check if user has a set a custom pref only on first run, not on each startup
       await this.trrModePrefHasUserValue("first_run", results);
       await this.enterprisePolicyCheck("first_run", results);
@@ -285,7 +309,7 @@ const rollout = {
     }
 
     // Only run the heuristics if user hasn't explicitly enabled/disabled DoH
-    let skipHeuristicsCheck = await this.getSetting("skipHeuristicsCheck");
+    let skipHeuristicsCheck = await this.getSetting("doh-rollout.skipHeuristicsCheck");
     log("skipHeuristicsCheck: ", skipHeuristicsCheck);
 
     if (!skipHeuristicsCheck) {

--- a/src/experiments/preferences/schema.json
+++ b/src/experiments/preferences/schema.json
@@ -136,7 +136,7 @@
         "parameters": [
           {
             "type": "string",
-            "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.disable-heuristics", "doh-rollout.doneFirstRun", "doh-rollout.skipHeuristicsCheck"]
+            "enum": ["doh-rollout.doorhanger-shown", "doh-rollout.self-enabled", "doh-rollout.disable-heuristics", "doh-rollout.doneFirstRun", "doh-rollout.skipHeuristicsCheck", "doh-rollout.balrog-migration-done"]
           },
           {
             "type": "boolean",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "1.1.0",
+  "version": "1.2.0rc1",
 
   "hidden": true,
 


### PR DESCRIPTION
This migration function updates the old local storage prefs to match the revised name space for all other local storage items

## To-do: 
- [x] Add `doh-rollout.balrog-migration-done` pref to Preferences API schema JSON
- [x] ~Add all other local storage prefs from v1.1 version. Moving entirely away from local storage~ No longer relevant 