### PR TITLE
Fixed #185 - Clear `doh-rollout.self-enabled` pref faster

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -240,13 +240,25 @@ const rollout = {
 
     switch (typeof defaultValue) {
     case "boolean":
-      log("boolean", name, await browser.experiments.preferences.getBoolPref(name, defaultValue));
+      log({
+        "type": "boolean",
+        "name": name,
+        "value": await browser.experiments.preferences.getBoolPref(name, defaultValue)
+      });
       return await browser.experiments.preferences.getBoolPref(name, defaultValue);
     case "number":
-      log("bumber", name, await browser.experiments.preferences.getIntPref(name, defaultValue));
+      log({
+        "type": "number",
+        "name": name,
+        "value": await browser.experiments.preferences.getIntPref(name, defaultValue)
+      });
       return await browser.experiments.preferences.getIntPref(name, defaultValue);
     case "string":
-      log("btring", name, await browser.experiments.preferences.getCharPref(name, defaultValue));
+      log({
+        "type": "string",
+        "name": name,
+        "value": await browser.experiments.preferences.getCharPref(name, defaultValue)
+      });
       return await browser.experiments.preferences.getCharPref(name, defaultValue);
     }
   },
@@ -459,8 +471,6 @@ const setup = {
     const runAddonPref = await rollout.getSetting(DOH_ENABLED_PREF, false);
     const runAddonBypassPref = await rollout.getSetting(DOH_SELF_ENABLED_PREF, false);
     const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, false);
-
-    log(runAddonPref);
 
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.

--- a/src/background.js
+++ b/src/background.js
@@ -90,7 +90,6 @@ const stateManager = {
 
   async rememberDisableHeuristics() {
     log("Remembering to never run heuristics again");
-    browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
     await rollout.setSetting(DOH_DISABLED_PREF, true);
   },
 
@@ -129,7 +128,9 @@ const stateManager = {
       if (curMode === 0 || curMode === 5) {
         // If user has manually set trr.mode to 0, and it was previously something else.
         browser.experiments.heuristics.sendHeuristicsPing("disable_doh", results);
+        browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
         await stateManager.rememberDisableHeuristics();
+
       } else {
         // Check if trr.mode is not in default value.
         await rollout.trrModePrefHasUserValue("shouldRunHeuristics_mismatch", results);
@@ -241,23 +242,23 @@ const rollout = {
     switch (typeof defaultValue) {
     case "boolean":
       log({
-        "type": "boolean",
-        "name": name,
-        "value": await browser.experiments.preferences.getBoolPref(name, defaultValue)
+        type: "boolean",
+        name,
+        value: await browser.experiments.preferences.getBoolPref(name, defaultValue)
       });
       return await browser.experiments.preferences.getBoolPref(name, defaultValue);
     case "number":
       log({
-        "type": "number",
-        "name": name,
-        "value": await browser.experiments.preferences.getIntPref(name, defaultValue)
+        type: "number",
+        name,
+        value: await browser.experiments.preferences.getIntPref(name, defaultValue)
       });
       return await browser.experiments.preferences.getIntPref(name, defaultValue);
     case "string":
       log({
-        "type": "string",
-        "name": name,
-        "value": await browser.experiments.preferences.getCharPref(name, defaultValue)
+        type: "string",
+        name,
+        value: await browser.experiments.preferences.getCharPref(name, defaultValue)
       });
       return await browser.experiments.preferences.getCharPref(name, defaultValue);
     }
@@ -306,6 +307,7 @@ const rollout = {
       // Send ping that user had specific trr.mode pref set before add-on study was ran.
       // Note that this does not include the trr.mode - just that the addon cannot be ran.
       browser.experiments.heuristics.sendHeuristicsPing("prefHasUserValue", results);
+      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       await stateManager.rememberDisableHeuristics();
       return;
     }

--- a/src/background.js
+++ b/src/background.js
@@ -90,6 +90,7 @@ const stateManager = {
 
   async rememberDisableHeuristics() {
     log("Remembering to never run heuristics again");
+    browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
     await rollout.setSetting(DOH_DISABLED_PREF, true);
   },
 
@@ -464,7 +465,6 @@ const setup = {
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
       // DoH status will not be modified from whatever the current setting is at runtime
-      browser.experiments.preferences.clearUserPref(DOH_SELF_ENABLED_PREF);
       log("Addon has been disabled. DoH status will not be modified from current setting");
       await stateManager.rememberDisableHeuristics();
       return;


### PR DESCRIPTION
Also improves/resolves #184 

- Moved the logic to clear `doh-rollout.self-enabled` pref to occur at any event that should disable heuristics. ~at the same time as the `rememberDisableHeuristics()` is ran.~ This will remove the additional step of restarting the browser a SECOND time to clear the pref. 

Expected behavior: 

1. Enable add-on, turn on DoH via heuristics 
1. Manually modify your DoH settings via about:preferences#networking (Uncheck DoH)
1. Trigger heuristics check by restarting browser OR change network. 
1. Confirm that the pref, `doh-rollout.self-enabled` has no value. 

_Note that changing your network connect takes at least 60s to fire (after switching networks)._ 