### PR TITLE
Fixed #188 - Removed `doh-rollout.remote-disable` from observer function

### DIFF
--- a/src/experiments/preferences/api.js
+++ b/src/experiments/preferences/api.js
@@ -68,10 +68,8 @@ var preferences = class preferences extends ExtensionAPI {
                 fire.async();
               };
               Services.prefs.addObserver("doh-rollout.enabled", observer);
-              Services.prefs.addObserver("doh-rollout.remote-disable", observer);
               return () => {
                 Services.prefs.removeObserver("doh-rollout.enabled", observer);
-                Services.prefs.removeObserver("doh-rollout.remote-disable", observer);
               };
             },
           }).api(),


### PR DESCRIPTION
This pref was left over from the v1.1 PR. It can/may be added back later to address #178!