### PR TITLE
Fixed #190 - Added logic to enable add-on based on local storage migration values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "1.2.0rc1",
+	"version": "1.2.0rc2",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -261,6 +261,7 @@ const rollout = {
     switch (typeof defaultValue) {
     case "boolean":
       log({
+        context: "getSetting",
         type: "boolean",
         name,
         value: await browser.experiments.preferences.getBoolPref(name, defaultValue)
@@ -268,6 +269,7 @@ const rollout = {
       return await browser.experiments.preferences.getBoolPref(name, defaultValue);
     case "number":
       log({
+        context: "getSetting",
         type: "number",
         name,
         value: await browser.experiments.preferences.getIntPref(name, defaultValue)
@@ -275,6 +277,7 @@ const rollout = {
       return await browser.experiments.preferences.getIntPref(name, defaultValue);
     case "string":
       log({
+        context: "getSetting",
         type: "string",
         name,
         value: await browser.experiments.preferences.getCharPref(name, defaultValue)
@@ -396,7 +399,7 @@ const rollout = {
       let data = await browser.storage.local.get(item);
       let value = data[item];
 
-      log({item, value});
+      log({context: "migration", item, value});
 
       if (data.hasOwnProperty(item)) {
         let migratedName = item;
@@ -541,6 +544,7 @@ const setup = {
     const runAddonPref = await rollout.getSetting(DOH_ENABLED_PREF, false);
     const runAddonBypassPref = await rollout.getSetting(DOH_SELF_ENABLED_PREF, false);
     const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, "");
+    const runAddonPreviousTRRMode = await rollout.getSetting(DOH_PREVIOUS_TRR_MODE_PREF, 0);
 
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.
@@ -555,6 +559,7 @@ const setup = {
       runAddonBypassPref ||
       runAddonDoorhangerDecision === "UIOk" ||
       runAddonDoorhangerDecision === "enabled" ||
+      runAddonPreviousTRRMode === 2 ||
       isNormandyStudy
     ) {
       // Confirms that the Normandy/default branch gate keeping pref is set to true,

--- a/src/background.js
+++ b/src/background.js
@@ -386,19 +386,17 @@ const rollout = {
       "doneFirstRun",
       "skipHeuristicsCheck",
       DOH_ENABLED_PREF,
-      TRR_MODE_PREF,
-      DOH_SELF_ENABLED_PREF,
       DOH_PREVIOUS_TRR_MODE_PREF,
       DOH_DOORHANGER_SHOWN_PREF,
       DOH_DOORHANGER_USER_DECISION_PREF,
       DOH_DISABLED_PREF,
-      DOH_SKIP_HEURISTICS_PREF,
-      DOH_DONE_FIRST_RUN_PREF
     ];
 
     for (let item of legacyLocalStorageKeys) {
       let data = await browser.storage.local.get(item);
       let value = data[item];
+
+      log({item, value});
 
       if (data.hasOwnProperty(item)) {
         let migratedName = item;

--- a/src/background.js
+++ b/src/background.js
@@ -531,6 +531,8 @@ async function checkNormandyAddonStudy() {
 
 const setup = {
   async start() {
+    showConsoleLogs = await browser.experiments.preferences.getBoolPref(DOH_DEBUG_PREF, false);
+
     // Run Migration First, to continue to run rest of start up logic
     await rollout.migrateLocalStoragePrefs();
 
@@ -538,9 +540,7 @@ const setup = {
     const isAddonDisabled = await rollout.getSetting(DOH_DISABLED_PREF, false);
     const runAddonPref = await rollout.getSetting(DOH_ENABLED_PREF, false);
     const runAddonBypassPref = await rollout.getSetting(DOH_SELF_ENABLED_PREF, false);
-    const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, false);
-
-    showConsoleLogs = await browser.experiments.preferences.getBoolPref(DOH_DEBUG_PREF, false);
+    const runAddonDoorhangerDecision = await rollout.getSetting(DOH_DOORHANGER_USER_DECISION_PREF, "");
 
     if (isAddonDisabled) {
       // Regardless of pref, the user has chosen/heuristics dictated that this add-on should be disabled.

--- a/src/background.js
+++ b/src/background.js
@@ -560,6 +560,7 @@ const setup = {
       runAddonDoorhangerDecision === "UIOk" ||
       runAddonDoorhangerDecision === "enabled" ||
       runAddonPreviousTRRMode === 2 ||
+      runAddonPreviousTRRMode === 0 ||
       isNormandyStudy
     ) {
       // Confirms that the Normandy/default branch gate keeping pref is set to true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "1.2.0rc1",
+  "version": "1.2.0rc2",
 
   "hidden": true,
 


### PR DESCRIPTION
## To verify: 

### Scenarios

- A. DoH turned on, user did not interact with doorhanger
- B. DoH turned on, user clicked “Enable” on doorhanger
- C. DoH turned on, user clicked “Enable” on doorhanger, network changed, turning DoH off 
- D. DoH turned off, user clicked “Disabled” on doorhanger


### 1. Setup v1.0.4 Add-on

- Install v1.0.4 add-on ([Signed XPI](https://github.com/mozilla/doh-rollout/releases/download/1.0.4/doh_roll-out-1.0.4-signed.xpi))
- Verify v1.0.4 via about:support 
  - Listed under “extensions”
- In about:config
  - Add boolean pref `doh-rollout.enabled` set to true
  - _Optional:_ Add boolean pref `doh-rollout.debug` set to true

### 2. Remove v1.0.4 Add-on

- Go to about:config, and reset `doh-rollout.enabled` pref
- Go to about:profiles, go to local directory of active profile
- Quit browser
- Delete /extensions folder 
- Restart browser
- Verify via about:support that DoH is no longer listed
- Verify that `network.trr.mode` is set to 2
- Verify add-on has set local storage items
- Go to: about:devtools-toolbox?type=extension&id=doh-rollout%40mozilla.org*
- Run the following command: 

      await browser.storage.local.get()

#### Expected responses: 

| Scenario | Response |
| -- | -- |
| A | `{ "doh-rollout.previous.trr.mode": 2, doneFirstRun: true, skipHeuristicsCheck: false }`|
| B | `{ "doh-rollout.doorhanger-decision": "UIOk", "doh-rollout.doorhanger-ping-sent": true, "doh-rollout.doorhanger-shown": true, "doh-rollout.previous.trr.mode": 2, doneFirstRun: true, skipHeuristicsCheck: false }` |
| C | `{ "doh-rollout.doorhanger-decision": "UIOk", "doh-rollout.doorhanger-ping-sent": true, "doh-rollout.doorhanger-shown": true, "doh-rollout.previous.trr.mode": 0, doneFirstRun: true, skipHeuristicsCheck: false }` | 
| D | `{ "doh-rollout.disable-heuristics": true, "doh-rollout.doorhanger-decision": "UIDisabled", "doh-rollout.doorhanger-ping-sent": true, "doh-rollout.doorhanger-shown": true, "doh-rollout.previous.trr.mode": 5, doneFirstRun: true, skipHeuristicsCheck: false }` |


*_If the above does not work, do the following:_ 
- Turn pref `devtools.aboutdebugging.showHiddenAddons` to true
- Go to about:debugging#/runtime/this-firefox
- Scroll to the bottom of the Extensions list
- Click “inspect” button on **DoH Roll-Out** add-on
- Expected: Open console for add-on code. Run the snippet mentioned above here.  

### 3. Install v1.2.0rc1 Add-on

- Install v1.1.2rc2 add-on ([Signed XPI](https://github.com/mozilla/doh-rollout/releases/download/1.2.0rc2/doh_roll-out-1.2.0rc2-signed.xpi)) 
- Verify add-on in about:support, listed under “extensions”
- Scenario expectations table: 

|Scenario |Prefs |Doorhanger Behavior |
|--|--|--|
| A | `doh-rollout.balrog-migration-done;true`<br> `doh-rollout.doneFirstRun;true`<br> `doh-rollout.previous.trr.mode;2`<br> `doh-rollout.self-enabled;true`<br> `doh-rollout.skipHeuristicsCheck;false ` | Should be visible |
| B | `doh-rollout.balrog-migration-done;true` <br> `doh-rollout.doneFirstRun;true` <br> `doh-rollout.doorhanger-decision;UIOk` <br> `doh-rollout.doorhanger-shown;true` <br> `doh-rollout.previous.trr.mode;2` <br> `doh-rollout.self-enabled;true` <br> `doh-rollout.skipHeuristicsCheck;false` <br> | Should be hidden | 
| C | `doh-rollout.balrog-migration-done;true` <br> `doh-rollout.doneFirstRun;true` <br> `doh-rollout.doorhanger-decision;UIOk` <br> `doh-rollout.doorhanger-shown;true` <br> `doh-rollout.previous.trr.mode;2` <br> `doh-rollout.self-enabled;true` <br> `doh-rollout.skipHeuristicsCheck;false` <br> | Should be hidden | 
| D | `doh-rollout.balrog-migration-done;true` <br> `doh-rollout.disable-heuristics;true` <br>  | Should be hidden | 

- If self-enabled is set to true, continue with additional testing to verify add-on is behaving as expected. 
- If debug logging is set to true, see those logs at about:devtools-toolbox?type=extension&id=doh-rollout%40mozilla.org 

