### PR TITLE
Add "Helper" Slug to Normandy Check Function for v2 Study

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doh-rollout",
-	"version": "1.2.0rc4",
+	"version": "1.2.0rc5",
 	"description": "DoH Roll-Out",
 	"main": "background.js",
 	"scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -513,6 +513,15 @@ const rollout = {
   },
 };
 
+
+/**
+ * checkNormandyAddonStudy
+ * This functions detects if a Normandy study is present, and then checks the branch
+ * to see the add-on should be enabled. If it gets a branch that it is not expecting,
+ * it throws an error.
+ *
+ * @return {boolean}  description
+ */
 async function checkNormandyAddonStudy() {
   const study = await browser.normandyAddonStudy.getStudy();
 
@@ -524,11 +533,7 @@ async function checkNormandyAddonStudy() {
   const branch = study.branch;
   switch (branch) {
   case "helper":
-    // This case is not return true/false as its user branch contains users from
-    // both the experiement and the control branches. However, this function
-    // in conjunction with migrateLocalStoragePrefs() will turn on for the users
-    // who should, and not for those who shouldn't.
-    return null;
+    return false;
   case "doh-rollout-heuristics":
     return true;
   case "doh-rollout-disabled":

--- a/src/background.js
+++ b/src/background.js
@@ -523,6 +523,12 @@ async function checkNormandyAddonStudy() {
 
   const branch = study.branch;
   switch (branch) {
+  case "helper":
+    // This case is not return true/false as its user branch contains users from
+    // both the experiement and the control branches. However, this function
+    // in conjunction with migrateLocalStoragePrefs() will turn on for the users
+    // who should, and not for those who shouldn't.
+    return null;
   case "doh-rollout-heuristics":
     return true;
   case "doh-rollout-disabled":

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
   "description": "__MSG_extensionDescription__",
-  "version": "1.2.0rc4",
+  "version": "1.2.0rc5",
 
   "hidden": true,
 


### PR DESCRIPTION
Fixed #209 - Added helper slug to `checkNormandyAddonStudy` function, s…o that users from that study are not thrown an error

## Testing Steps

- Start with clean profile on [unsigned latest build](https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)
- Install the [Normandy Dev Tools](https://github.com/mozilla/normandy-devtools/releases/download/v0.8.0/normandy-devtools@mozilla.com-0.8.0-signed.xpi)
- Once installed, clicked the Wrench icon
- In the Normandy Dev Tools, run [this script](https://gist.github.com/9b1b30d4e28eb7f1e24d6364027452e4) via "Write & Run Arbitrary"  to enroll in v2 Helper Study
- Restart browser
- Verify you have the add-on via `about:support`
- Verify you are enrolled in the study via `about:studies`
- Depending on your testing scenario, add the following prefs: 
  - `doh-rollout.enabled` : `true`
  - `doh-rollout.debug` : `true`
- If you add `doh-rollout.enabled:true;`, you will get the Doorhanger (if heuristics allow it) 
- Close browser
- Delete doh-rollout extension from /extensions directory in profile files. 
- Open browser, remove/reset pref `doh-rollout.enabled` entirely. 
- Run this add-on (via `web-ext`) in the correct version of FF and correct profile. 
- Navigate to `about:debugging#/runtime/this-firefox`, click "Inspect" button on the DoH Rollout add-on
- In that console, you should see the following:
  - _Note: The values will be different based on if the add-on turned DoH on/off, but regardless, if the add-on ran, you will have sort of objects returned from the `migrateLocalStoragePrefs` function._
```Javascript
Object { context: "migration", item: "doneFirstRun", value: true }
Object { context: "migration", item: "skipHeuristicsCheck", value: false }
Object { context: "migration", item: "doh-rollout.previous.trr.mode", value: 2 }
Object { context: "migration", item: "doh-rollout.doorhanger-shown", value: true }
Object { context: "migration", item: "doh-rollout.doorhanger-decision", value: "UIOk" }
Object { context: "migration", item: "doh-rollout.disable-heuristics", value: undefined } 
```

Additional directions for testing (along with expected responses) can be found [here](https://docs.google.com/document/d/1F6nlv-R6PzUxNKTMpF5F2jIZf7kNTFcBYR4DU3-Xsrk/edit?usp=sharing). 
